### PR TITLE
feat(feedback): add ability to retrigger webhook for feedback items

### DIFF
--- a/backend/tests/feedback/test_feedback_router.py
+++ b/backend/tests/feedback/test_feedback_router.py
@@ -223,3 +223,37 @@ class TestDeleteFeedbackAdminEndpoint:
         response = await admin_client.delete(f"/api/v1/feedback/admin/{uuid.uuid4()}")
 
         assert response.status_code == 404
+
+
+class TestRetriggerFeedbackWebhookEndpoint:
+    """Tests for POST /api/v1/feedback/admin/{feedback_id}/retrigger-webhook."""
+
+    async def test_retrigger_webhook_as_admin(
+        self, admin_client: AsyncClient, test_feedback: Feedback
+    ):
+        """Test re-triggering webhook as admin."""
+        response = await admin_client.post(
+            f"/api/v1/feedback/admin/{test_feedback.id}/retrigger-webhook"
+        )
+
+        assert response.status_code == 202
+        data = response.json()
+        assert data["message"] == "Webhook re-triggered successfully"
+
+    async def test_retrigger_webhook_as_non_admin(
+        self, authenticated_client: AsyncClient, test_feedback: Feedback
+    ):
+        """Test that non-admin gets 403."""
+        response = await authenticated_client.post(
+            f"/api/v1/feedback/admin/{test_feedback.id}/retrigger-webhook"
+        )
+
+        assert response.status_code == 403
+
+    async def test_retrigger_webhook_not_found(self, admin_client: AsyncClient):
+        """Test re-triggering webhook for non-existent feedback."""
+        response = await admin_client.post(
+            f"/api/v1/feedback/admin/{uuid.uuid4()}/retrigger-webhook"
+        )
+
+        assert response.status_code == 404

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -4,6 +4,7 @@
     "save": "Save",
     "cancel": "Cancel",
     "delete": "Delete",
+    "success": "Success",
     "edit": "Edit",
     "create": "Create",
     "update": "Update",
@@ -407,7 +408,10 @@
     "filterByStatus": "Filter by status",
     "filterByType": "Filter by type",
     "allStatuses": "All Statuses",
-    "allTypes": "All Types"
+    "allTypes": "All Types",
+    "retriggerWebhook": "Retrigger Webhook",
+    "retriggerWebhookSuccess": "Webhook has been re-triggered successfully",
+    "retriggerWebhookConfirm": "This will re-trigger the feedback.created webhook event for this feedback item. Are you sure?"
   },
   "errors": {
     "somethingWentWrong": "Something went wrong",

--- a/frontend/src/lib/api/api-client.ts
+++ b/frontend/src/lib/api/api-client.ts
@@ -893,6 +893,14 @@ export const adminApi = {
 
   deleteFeedback: (id: string) =>
     apiRequest<void>(`/api/v1/feedback/admin/${id}`, { method: "DELETE" }),
+
+  retriggerFeedbackWebhook: (id: string) =>
+    apiRequest<{ message: string }>(
+      `/api/v1/feedback/admin/${id}/retrigger-webhook`,
+      {
+        method: "POST",
+      }
+    ),
 };
 
 // Feedback Types


### PR DESCRIPTION
## Summary

- Adds new admin endpoint `POST /api/v1/feedback/admin/{feedback_id}/retrigger-webhook` to re-trigger the `feedback.created` webhook event
- Adds "Retrigger Webhook" button in the admin feedback detail dialog
- Useful for testing webhooks or when webhook configuration was changed after feedback was submitted

## Test plan

- [ ] Open admin feedback page and view a feedback item
- [ ] Click "Retrigger Webhook" button and confirm
- [ ] Verify success message appears
- [ ] Check webhook execution logs to confirm webhook was triggered
- [ ] Verify non-admin users cannot access the endpoint (403)

🤖 Generated with [Claude Code](https://claude.com/claude-code)