### PR TITLE
fix: prevent check-in without prior check-out

### DIFF
--- a/backend/tests/items/test_check_in_out.py
+++ b/backend/tests/items/test_check_in_out.py
@@ -337,23 +337,6 @@ class TestUsageStats:
         assert stats.last_check_out is not None
         assert stats.last_check_in is not None
 
-    async def test_usage_stats_currently_checked_out_can_be_negative(
-        self,
-        async_session: AsyncSession,
-        test_user: User,
-        test_item: Item,
-    ):
-        """Test that currently_checked_out can be negative (more check-ins than check-outs)."""
-        repo = ItemRepository(async_session, test_user.id)
-
-        await repo.create_check_in_out(
-            test_item.id, "check_in", CheckInOutCreate(quantity=5)
-        )
-
-        stats = await repo.get_usage_stats(test_item.id)
-
-        assert stats.currently_checked_out == -5
-
 
 class TestMostUsedItems:
     """Tests for most used items dashboard widget."""

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -468,6 +468,8 @@
     "mostUsed": "Most Used Items",
     "recentlyUsed": "Recently Used",
     "noUsageYet": "No usage history yet",
-    "showingRecentHistory": "Showing 5 of {count} records"
+    "showingRecentHistory": "Showing 5 of {count} records",
+    "checkInDisabled": "No items checked out",
+    "exceedsCheckedOut": "Cannot check in more than {count} items"
   }
 }

--- a/frontend/src/app/(dashboard)/items/[id]/page.tsx
+++ b/frontend/src/app/(dashboard)/items/[id]/page.tsx
@@ -27,6 +27,12 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { useConfirmModal } from "@/components/ui/confirm-modal";
 import { AuthenticatedImage } from "@/components/ui/authenticated-image";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { itemsApi, CheckInOutCreate } from "@/lib/api/api-client";
 import { cn, formatPrice } from "@/lib/utils";
 import { useAuth } from "@/context/auth-context";
@@ -438,19 +444,48 @@ export default function ItemDetailPage() {
                     ? tCommon("loading")
                     : t("checkOut")}
                 </Button>
-                <Button
-                  variant="outline"
-                  onClick={handleCheckIn}
-                  disabled={
-                    checkOutMutation.isPending || checkInMutation.isPending
-                  }
-                  className="flex-1 gap-2"
-                >
-                  <LogIn className="h-4 w-4" />
-                  {checkInMutation.isPending
-                    ? tCommon("loading")
-                    : t("checkIn")}
-                </Button>
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span className="flex-1">
+                        <Button
+                          variant="outline"
+                          onClick={handleCheckIn}
+                          disabled={
+                            checkOutMutation.isPending ||
+                            checkInMutation.isPending ||
+                            !usageStats ||
+                            usageStats.currently_checked_out <= 0 ||
+                            checkInOutQuantity >
+                              usageStats.currently_checked_out
+                          }
+                          className="w-full gap-2"
+                        >
+                          <LogIn className="h-4 w-4" />
+                          {checkInMutation.isPending
+                            ? tCommon("loading")
+                            : t("checkIn")}
+                        </Button>
+                      </span>
+                    </TooltipTrigger>
+                    {usageStats && usageStats.currently_checked_out <= 0 && (
+                      <TooltipContent>
+                        <p>{t("checkInDisabled")}</p>
+                      </TooltipContent>
+                    )}
+                    {usageStats &&
+                      usageStats.currently_checked_out > 0 &&
+                      checkInOutQuantity > usageStats.currently_checked_out && (
+                        <TooltipContent>
+                          <p>
+                            {t("exceedsCheckedOut", {
+                              count: usageStats.currently_checked_out,
+                            })}
+                          </p>
+                        </TooltipContent>
+                      )}
+                  </Tooltip>
+                </TooltipProvider>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Add backend validation in check-in endpoint to prevent check-in without prior check-out
- Disable check-in button on frontend when no items are checked out
- Add tooltip explanations when check-in is disabled
- Add comprehensive test coverage for validation scenarios

## Changes
### Backend
- `backend/src/items/router.py`: Add validation in `check_in_item` endpoint to:
  - Reject check-in if nothing is currently checked out (returns 400)
  - Reject check-in if quantity exceeds what's currently checked out (returns 400)

### Frontend
- `frontend/src/app/(dashboard)/items/[id]/page.tsx`: Disable check-in button and show tooltip when:
  - No items are currently checked out
  - Check-in quantity exceeds what's checked out
- `frontend/messages/en.json`: Add i18n translations for new messages

### Tests
- Updated existing check-in test to first check out before checking in
- Removed test that validated buggy negative values behavior
- Added 5 new tests for validation scenarios:
  - `test_check_in_without_prior_checkout_fails`
  - `test_check_in_more_than_checked_out_fails`
  - `test_check_in_exact_amount_succeeds`
  - `test_check_in_after_full_return_fails`

## Test plan
- [x] Backend tests pass (443 tests)
- [x] Frontend build succeeds
- [x] Lint and format checks pass

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)