### PR TITLE
fix: prevent negative 'currently out' item count on check-in

### DIFF
--- a/backend/src/items/repository.py
+++ b/backend/src/items/repository.py
@@ -259,6 +259,16 @@ class ItemRepository:
         result = await self.session.execute(query)
         return result.scalar_one_or_none()
 
+    async def get_by_id_for_update(self, item_id: UUID) -> Item | None:
+        """Get an item by ID with a row-level lock for update.
+
+        Uses SELECT ... FOR UPDATE to prevent race conditions during
+        concurrent check-in/check-out operations.
+        """
+        query = self._base_query().where(Item.id == item_id).with_for_update()
+        result = await self.session.execute(query)
+        return result.scalar_one_or_none()
+
     async def create(self, data: ItemCreate) -> Item:
         """Create a new item.
 


### PR DESCRIPTION
## Summary
- Add row-level locking (`SELECT ... FOR UPDATE`) to the check-in endpoint to prevent race conditions
- Add `get_by_id_for_update()` method to ItemRepository for acquiring row-level locks
- Add test coverage for sequential check-in validation

## Problem
Users could check in items that hadn't been checked out, resulting in negative 'currently out' item counts. While validation existed, concurrent requests could bypass it due to a TOCTOU (Time-of-Check to Time-of-Use) race condition.

## Solution
The fix uses PostgreSQL row-level locking to serialize concurrent check-in requests. When a check-in request comes in:
1. It acquires a lock on the Item row (`SELECT ... FOR UPDATE`)
2. Validates the current checked-out count
3. Creates the check-in record
4. Commits (releasing the lock)

This ensures the validation and insert are atomic - a second concurrent request will wait for the lock and see the updated state.

## Test plan
- [x] Run backend linting: `uv run ruff check .`
- [x] Run backend formatting: `uv run ruff format --check .`
- [x] Run backend tests: `uv run pytest` (621 passed, 1 skipped)
- [x] Added test `test_check_in_prevents_negative_count_sequential` to verify validation works

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)