### PR TITLE
feat(items): add batch update and filter by uncategorized/no location

### DIFF
--- a/backend/src/items/schemas.py
+++ b/backend/src/items/schemas.py
@@ -233,3 +233,24 @@ class FindSimilarResponse(BaseModel):
 
     similar_items: list[SimilarItemMatch]
     total_searched: int
+
+
+class BatchUpdateRequest(BaseModel):
+    """Schema for batch updating multiple items."""
+
+    item_ids: list[UUID] = Field(..., min_length=1, max_length=100)
+    category_id: UUID | None = None
+    location_id: UUID | None = None
+    clear_category: bool = Field(
+        default=False, description="Set to true to remove category from items"
+    )
+    clear_location: bool = Field(
+        default=False, description="Set to true to remove location from items"
+    )
+
+
+class BatchUpdateResponse(BaseModel):
+    """Response for batch update operation."""
+
+    updated_count: int
+    item_ids: list[UUID]

--- a/backend/tests/items/test_items_router.py
+++ b/backend/tests/items/test_items_router.py
@@ -776,3 +776,230 @@ class TestItemQRCodeEndpoint:
         assert response.status_code == 200
         assert "cache-control" in response.headers
         assert "max-age" in response.headers["cache-control"]
+
+
+class TestListItemsFilterByNoCategory:
+    """Tests for GET /api/v1/items with no_category filter."""
+
+    async def test_filter_items_without_category(
+        self, authenticated_client: AsyncClient, async_session, test_user
+    ):
+        """Test filtering items that have no category assigned."""
+        # Create an item without a category
+        uncategorized_item = Item(
+            name="Uncategorized Item",
+            quantity=1,
+            user_id=test_user.id,
+            category_id=None,
+        )
+        async_session.add(uncategorized_item)
+        await async_session.commit()
+
+        response = await authenticated_client.get(
+            "/api/v1/items", params={"no_category": "true"}
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["items"]) == 1
+        assert data["items"][0]["name"] == "Uncategorized Item"
+
+    async def test_filter_excludes_categorized_items(
+        self,
+        authenticated_client: AsyncClient,
+        test_item: Item,  # This has a category
+    ):
+        """Test that items with category are excluded when filtering for uncategorized."""
+        response = await authenticated_client.get(
+            "/api/v1/items", params={"no_category": "true"}
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["items"]) == 0
+
+
+class TestListItemsFilterByNoLocation:
+    """Tests for GET /api/v1/items with no_location filter."""
+
+    async def test_filter_items_without_location(
+        self, authenticated_client: AsyncClient, async_session, test_user
+    ):
+        """Test filtering items that have no location assigned."""
+        # Create an item without a location
+        no_location_item = Item(
+            name="No Location Item",
+            quantity=1,
+            user_id=test_user.id,
+            location_id=None,
+        )
+        async_session.add(no_location_item)
+        await async_session.commit()
+
+        response = await authenticated_client.get(
+            "/api/v1/items", params={"no_location": "true"}
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["items"]) == 1
+        assert data["items"][0]["name"] == "No Location Item"
+
+    async def test_filter_excludes_items_with_location(
+        self,
+        authenticated_client: AsyncClient,
+        test_item: Item,  # This has a location
+    ):
+        """Test that items with location are excluded when filtering for no location."""
+        response = await authenticated_client.get(
+            "/api/v1/items", params={"no_location": "true"}
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["items"]) == 0
+
+
+class TestBatchUpdateItemsEndpoint:
+    """Tests for PATCH /api/v1/items/batch."""
+
+    async def test_batch_update_category(
+        self,
+        authenticated_client: AsyncClient,
+        async_session,
+        test_user,
+        test_category: Category,
+    ):
+        """Test batch updating items with a new category."""
+        # Create items without category
+        item1 = Item(name="Item 1", quantity=1, user_id=test_user.id, category_id=None)
+        item2 = Item(name="Item 2", quantity=2, user_id=test_user.id, category_id=None)
+        async_session.add_all([item1, item2])
+        await async_session.commit()
+        await async_session.refresh(item1)
+        await async_session.refresh(item2)
+
+        response = await authenticated_client.patch(
+            "/api/v1/items/batch",
+            json={
+                "item_ids": [str(item1.id), str(item2.id)],
+                "category_id": str(test_category.id),
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["updated_count"] == 2
+        assert len(data["item_ids"]) == 2
+
+    async def test_batch_update_location(
+        self,
+        authenticated_client: AsyncClient,
+        async_session,
+        test_user,
+        test_location: Location,
+    ):
+        """Test batch updating items with a new location."""
+        # Create items without location
+        item1 = Item(name="Item 1", quantity=1, user_id=test_user.id, location_id=None)
+        item2 = Item(name="Item 2", quantity=2, user_id=test_user.id, location_id=None)
+        async_session.add_all([item1, item2])
+        await async_session.commit()
+        await async_session.refresh(item1)
+        await async_session.refresh(item2)
+
+        response = await authenticated_client.patch(
+            "/api/v1/items/batch",
+            json={
+                "item_ids": [str(item1.id), str(item2.id)],
+                "location_id": str(test_location.id),
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["updated_count"] == 2
+
+    async def test_batch_update_clear_category(
+        self,
+        authenticated_client: AsyncClient,
+        test_item: Item,  # Has a category
+    ):
+        """Test batch clearing category from items."""
+        response = await authenticated_client.patch(
+            "/api/v1/items/batch",
+            json={
+                "item_ids": [str(test_item.id)],
+                "clear_category": True,
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["updated_count"] == 1
+
+        # Verify the item now has no category
+        item_response = await authenticated_client.get(f"/api/v1/items/{test_item.id}")
+        assert item_response.json()["category"] is None
+
+    async def test_batch_update_clear_location(
+        self,
+        authenticated_client: AsyncClient,
+        test_item: Item,  # Has a location
+    ):
+        """Test batch clearing location from items."""
+        response = await authenticated_client.patch(
+            "/api/v1/items/batch",
+            json={
+                "item_ids": [str(test_item.id)],
+                "clear_location": True,
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["updated_count"] == 1
+
+        # Verify the item now has no location
+        item_response = await authenticated_client.get(f"/api/v1/items/{test_item.id}")
+        assert item_response.json()["location"] is None
+
+    async def test_batch_update_empty_item_ids(self, authenticated_client: AsyncClient):
+        """Test batch update with empty item_ids list returns validation error."""
+        response = await authenticated_client.patch(
+            "/api/v1/items/batch",
+            json={"item_ids": []},
+        )
+
+        assert response.status_code == 422
+
+    async def test_batch_update_nonexistent_items(
+        self, authenticated_client: AsyncClient, test_category: Category
+    ):
+        """Test batch update with non-existent item IDs returns empty result."""
+        response = await authenticated_client.patch(
+            "/api/v1/items/batch",
+            json={
+                "item_ids": [str(uuid.uuid4()), str(uuid.uuid4())],
+                "category_id": str(test_category.id),
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["updated_count"] == 0
+        assert len(data["item_ids"]) == 0
+
+    async def test_batch_update_unauthenticated(
+        self, unauthenticated_client: AsyncClient
+    ):
+        """Test that unauthenticated request returns 401."""
+        response = await unauthenticated_client.patch(
+            "/api/v1/items/batch",
+            json={
+                "item_ids": [str(uuid.uuid4())],
+                "category_id": str(uuid.uuid4()),
+            },
+        )
+
+        assert response.status_code == 401

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -101,6 +101,8 @@
     "allCategories": "All Categories",
     "allLocations": "All Locations",
     "lowStockOnly": "Low stock only",
+    "uncategorizedOnly": "Uncategorized",
+    "noLocationOnly": "No location",
     "filterByTags": "Filter by tags",
     "loadingItems": "Loading items...",
     "noItemsFound": "No items found",
@@ -131,7 +133,18 @@
     "images": "Images",
     "notes": "Notes",
     "price": "Price",
-    "quantityEstimateFromAi": "AI estimate: {estimate}"
+    "quantityEstimateFromAi": "AI estimate: {estimate}",
+    "selectAll": "Select all",
+    "deselectAll": "Deselect all",
+    "selectedCount": "{count} selected",
+    "batchUpdateTitle": "Update Selected Items",
+    "setCategory": "Set category",
+    "setLocation": "Set location",
+    "clearCategory": "Clear category",
+    "clearLocation": "Clear location",
+    "applyChanges": "Apply Changes",
+    "batchUpdateSuccess": "Successfully updated {count} items",
+    "selectItems": "Select items to batch update"
   },
   "categories": {
     "title": "Categories",

--- a/frontend/src/lib/api/api-client.ts
+++ b/frontend/src/lib/api/api-client.ts
@@ -139,6 +139,8 @@ export const itemsApi = {
     include_subcategories?: boolean;
     location_id?: string;
     include_sublocations?: boolean;
+    no_category?: boolean;
+    no_location?: boolean;
     search?: string;
     tags?: string[];
     attributes?: Record<string, string>;
@@ -155,6 +157,8 @@ export const itemsApi = {
       searchParams.set("location_id", params.location_id);
     if (params?.include_sublocations === false)
       searchParams.set("include_sublocations", "false");
+    if (params?.no_category) searchParams.set("no_category", "true");
+    if (params?.no_location) searchParams.set("no_location", "true");
     if (params?.search) searchParams.set("search", params.search);
     if (params?.tags) {
       params.tags.forEach((tag) => searchParams.append("tags", tag));
@@ -262,6 +266,12 @@ export const itemsApi = {
   findSimilar: (data: FindSimilarRequest) =>
     apiRequest<FindSimilarResponse>("/api/v1/items/find-similar", {
       method: "POST",
+      body: data,
+    }),
+
+  batchUpdate: (data: BatchUpdateRequest) =>
+    apiRequest<BatchUpdateResponse>("/api/v1/items/batch", {
+      method: "PATCH",
       body: data,
     }),
 };
@@ -566,6 +576,19 @@ export type ItemCreate = {
 };
 
 export type ItemUpdate = Partial<ItemCreate>;
+
+export type BatchUpdateRequest = {
+  item_ids: string[];
+  category_id?: string | null;
+  location_id?: string | null;
+  clear_category?: boolean;
+  clear_location?: boolean;
+};
+
+export type BatchUpdateResponse = {
+  updated_count: number;
+  item_ids: string[];
+};
 
 export type FacetValue = {
   value: string;


### PR DESCRIPTION
## Summary
- Add filter checkboxes on items page to show items without a category or location
- Add batch selection mode to select multiple items and update their category/location at once
- Add new backend endpoint `PATCH /api/v1/items/batch` for batch updates
- Add comprehensive tests for new functionality

## Changes

### Backend
- Add `no_category` and `no_location` query parameters to `GET /api/v1/items`
- Add `PATCH /api/v1/items/batch` endpoint for batch updating items
- Add `BatchUpdateRequest` and `BatchUpdateResponse` schemas
- Add `batch_update` method to `ItemRepository`

### Frontend  
- Add "Uncategorized" and "No location" filter checkboxes in the filter panel
- Add selection mode with select all/deselect all toggle
- Add visual indicators for selected items in both grid and table views
- Add batch update panel for setting or clearing category/location on multiple items

### Tests
- Add 11 new backend tests for filters and batch update endpoint

## Test plan
- [ ] Filter items by "Uncategorized" checkbox - should only show items without a category
- [ ] Filter items by "No location" checkbox - should only show items without a location
- [ ] Enter selection mode by clicking "Select items" button
- [ ] Select multiple items using checkboxes (works in both grid and table views)
- [ ] Use "Select all" to select all visible items
- [ ] Open batch update panel and set a category - items should be updated
- [ ] Use "Clear category" option to remove category from selected items
- [ ] Verify backend tests pass: `uv run pytest tests/items/test_items_router.py -v`

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)