### PR TITLE
feat(apikeys): add API key authentication for external integrations

### DIFF
--- a/.github/workflows/sync-feedback.yml
+++ b/.github/workflows/sync-feedback.yml
@@ -1,0 +1,114 @@
+name: Sync Feedback Status
+
+on:
+  issues:
+    types: [closed]
+
+jobs:
+  resolve-feedback:
+    name: Resolve Feedback
+    runs-on: ubuntu-latest
+    # Only run if the issue was closed (not deleted)
+    if: github.event.issue.state == 'closed'
+    steps:
+      - name: Extract feedback IDs from issue
+        id: extract-master
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const feedbackIds = [];
+
+            // Extract Feedback ID from the closed issue body
+            const regex = /Feedback ID:\s*([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/gi;
+            let match;
+            while ((match = regex.exec(issue.body || '')) !== null) {
+              feedbackIds.push(match[1]);
+            }
+
+            console.log(`Found ${feedbackIds.length} feedback ID(s) in issue #${issue.number}`);
+            return feedbackIds;
+
+      - name: Find duplicate issues
+        id: find-duplicates
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const duplicateFeedbackIds = [];
+
+            // Search for issues that were closed as duplicates of this one
+            // GitHub doesn't have a direct API for this, so we search for:
+            // 1. Issues that have a comment like "Duplicate of #123"
+            // 2. Issues closed around the same time that reference this issue
+
+            // Get all closed issues that mention this issue number
+            const searchQuery = `repo:${context.repo.owner}/${context.repo.repo} is:issue is:closed "#${issue.number}" in:body`;
+
+            try {
+              const { data: searchResults } = await github.rest.search.issuesAndPullRequests({
+                q: searchQuery,
+                per_page: 100
+              });
+
+              const regex = /Feedback ID:\s*([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/gi;
+
+              for (const dup of searchResults.items) {
+                // Skip the master issue itself
+                if (dup.number === issue.number) continue;
+
+                let match;
+                while ((match = regex.exec(dup.body || '')) !== null) {
+                  duplicateFeedbackIds.push(match[1]);
+                }
+              }
+            } catch (error) {
+              console.log('Error searching for duplicates:', error.message);
+            }
+
+            console.log(`Found ${duplicateFeedbackIds.length} feedback ID(s) in duplicate issues`);
+            return duplicateFeedbackIds;
+
+      - name: Resolve feedback items
+        env:
+          HOMERP_API_URL: ${{ secrets.HOMERP_API_URL }}
+          HOMERP_API_KEY: ${{ secrets.HOMERP_API_KEY }}
+        run: |
+          # Combine all feedback IDs from master and duplicates
+          MASTER_IDS='${{ steps.extract-master.outputs.result }}'
+          DUPLICATE_IDS='${{ steps.find-duplicates.outputs.result }}'
+
+          # Parse JSON arrays and combine unique IDs
+          ALL_IDS=$(echo "$MASTER_IDS $DUPLICATE_IDS" | jq -s 'add | unique | .[]' -r 2>/dev/null || echo "")
+
+          if [ -z "$ALL_IDS" ]; then
+            echo "No feedback IDs found to resolve"
+            exit 0
+          fi
+
+          if [ -z "$HOMERP_API_URL" ] || [ -z "$HOMERP_API_KEY" ]; then
+            echo "HOMERP_API_URL or HOMERP_API_KEY not configured"
+            exit 0
+          fi
+
+          echo "Resolving feedback items..."
+
+          for ID in $ALL_IDS; do
+            echo "Resolving feedback: $ID"
+            RESPONSE=$(curl -s -w "\n%{http_code}" -X PUT \
+              "${HOMERP_API_URL}/api/v1/feedback/admin/${ID}/resolve" \
+              -H "X-API-Key: ${HOMERP_API_KEY}" \
+              -H "Content-Type: application/json")
+
+            HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
+            BODY=$(echo "$RESPONSE" | sed '$d')
+
+            if [ "$HTTP_CODE" = "200" ]; then
+              echo "  ✓ Feedback $ID resolved successfully"
+            elif [ "$HTTP_CODE" = "404" ]; then
+              echo "  ⚠ Feedback $ID not found (may have been deleted)"
+            else
+              echo "  ✗ Failed to resolve feedback $ID (HTTP $HTTP_CODE)"
+              echo "    Response: $BODY"
+            fi
+          done

--- a/backend/alembic/versions/015_add_api_keys.py
+++ b/backend/alembic/versions/015_add_api_keys.py
@@ -1,0 +1,84 @@
+"""Add API keys table for external authentication
+
+Revision ID: 015
+Revises: 014
+Create Date: 2025-12-14
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "015"
+down_revision: str | None = "014"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Create api_keys table
+    op.create_table(
+        "api_keys",
+        sa.Column(
+            "id",
+            sa.UUID(),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column("user_id", sa.UUID(), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("key_hash", sa.String(length=64), nullable=False),
+        sa.Column("key_prefix", sa.String(length=8), nullable=False),
+        sa.Column("scopes", JSONB, nullable=False, server_default="[]"),
+        sa.Column(
+            "is_active",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("true"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("last_used_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["users.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("key_hash"),
+    )
+    op.create_index(op.f("ix_api_keys_user_id"), "api_keys", ["user_id"], unique=False)
+    op.create_index(op.f("ix_api_keys_key_hash"), "api_keys", ["key_hash"], unique=True)
+
+    # Enable Row Level Security
+    op.execute("ALTER TABLE api_keys ENABLE ROW LEVEL SECURITY")
+
+    # Create RLS policy for tenant isolation
+    op.execute("""
+        CREATE POLICY api_keys_tenant_isolation ON api_keys
+        FOR ALL
+        USING (user_id = current_setting('app.current_user_id', true)::uuid)
+        WITH CHECK (user_id = current_setting('app.current_user_id', true)::uuid)
+    """)
+
+
+def downgrade() -> None:
+    # Drop RLS policy
+    op.execute("DROP POLICY IF EXISTS api_keys_tenant_isolation ON api_keys")
+
+    # Disable RLS
+    op.execute("ALTER TABLE api_keys DISABLE ROW LEVEL SECURITY")
+
+    op.drop_index(op.f("ix_api_keys_key_hash"), table_name="api_keys")
+    op.drop_index(op.f("ix_api_keys_user_id"), table_name="api_keys")
+    op.drop_table("api_keys")

--- a/backend/src/apikeys/__init__.py
+++ b/backend/src/apikeys/__init__.py
@@ -1,0 +1,1 @@
+"""API Keys module for external system authentication."""

--- a/backend/src/apikeys/models.py
+++ b/backend/src/apikeys/models.py
@@ -1,0 +1,40 @@
+"""API Key database models."""
+
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import DateTime, ForeignKey, String, func
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from src.database import Base
+
+
+class ApiKey(Base):
+    """API Key model for external system authentication."""
+
+    __tablename__ = "api_keys"
+
+    id: Mapped[UUID] = mapped_column(
+        primary_key=True, server_default=func.gen_random_uuid()
+    )
+    user_id: Mapped[UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    key_hash: Mapped[str] = mapped_column(String(64), nullable=False, unique=True)
+    key_prefix: Mapped[str] = mapped_column(String(8), nullable=False)
+    scopes: Mapped[list[str]] = mapped_column(JSONB, nullable=False, default=list)
+    is_active: Mapped[bool] = mapped_column(nullable=False, default=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    last_used_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    expires_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+
+    # Relationships
+    user: Mapped["User"] = relationship(back_populates="api_keys")
+
+
+# Import at bottom to avoid circular imports
+from src.users.models import User  # noqa: E402, F811

--- a/backend/src/apikeys/repository.py
+++ b/backend/src/apikeys/repository.py
@@ -1,0 +1,99 @@
+"""API Key repository for database operations."""
+
+from datetime import UTC, datetime
+from uuid import UUID
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from src.apikeys.models import ApiKey
+from src.apikeys.schemas import ApiKeyUpdate
+
+
+class ApiKeyRepository:
+    """Repository for API key database operations."""
+
+    def __init__(self, session: AsyncSession, user_id: UUID | None = None):
+        self.session = session
+        self.user_id = user_id
+
+    async def create(
+        self,
+        user_id: UUID,
+        name: str,
+        key_hash: str,
+        key_prefix: str,
+        scopes: list[str],
+        expires_at: datetime | None = None,
+    ) -> ApiKey:
+        """Create a new API key."""
+        api_key = ApiKey(
+            user_id=user_id,
+            name=name,
+            key_hash=key_hash,
+            key_prefix=key_prefix,
+            scopes=scopes,
+            expires_at=expires_at,
+        )
+        self.session.add(api_key)
+        await self.session.commit()
+        await self.session.refresh(api_key)
+        return api_key
+
+    async def get_by_id(self, api_key_id: UUID) -> ApiKey | None:
+        """Get an API key by ID."""
+        result = await self.session.execute(
+            select(ApiKey)
+            .options(selectinload(ApiKey.user))
+            .where(ApiKey.id == api_key_id)
+        )
+        return result.scalar_one_or_none()
+
+    async def get_by_hash(self, key_hash: str) -> ApiKey | None:
+        """Get an API key by its hash (for validation)."""
+        result = await self.session.execute(
+            select(ApiKey)
+            .options(selectinload(ApiKey.user))
+            .where(ApiKey.key_hash == key_hash)
+        )
+        return result.scalar_one_or_none()
+
+    async def get_user_keys(
+        self, user_id: UUID, offset: int = 0, limit: int = 20
+    ) -> list[ApiKey]:
+        """Get all API keys for a user."""
+        result = await self.session.execute(
+            select(ApiKey)
+            .where(ApiKey.user_id == user_id)
+            .order_by(ApiKey.created_at.desc())
+            .offset(offset)
+            .limit(limit)
+        )
+        return list(result.scalars().all())
+
+    async def count_user_keys(self, user_id: UUID) -> int:
+        """Count API keys for a user."""
+        result = await self.session.execute(
+            select(func.count(ApiKey.id)).where(ApiKey.user_id == user_id)
+        )
+        return result.scalar_one()
+
+    async def update(self, api_key: ApiKey, data: ApiKeyUpdate) -> ApiKey:
+        """Update an API key."""
+        update_data = data.model_dump(exclude_unset=True)
+        for field, value in update_data.items():
+            setattr(api_key, field, value)
+        await self.session.commit()
+        await self.session.refresh(api_key)
+        return api_key
+
+    async def update_last_used(self, api_key: ApiKey) -> None:
+        """Update the last_used_at timestamp."""
+        api_key.last_used_at = datetime.now(UTC)
+        await self.session.commit()
+
+    async def delete(self, api_key: ApiKey) -> None:
+        """Delete an API key."""
+        await self.session.delete(api_key)
+        await self.session.commit()

--- a/backend/src/apikeys/router.py
+++ b/backend/src/apikeys/router.py
@@ -1,0 +1,155 @@
+"""API Key management routes (admin only)."""
+
+from uuid import UUID
+
+from fastapi import APIRouter, HTTPException, Query, status
+
+from src.apikeys.repository import ApiKeyRepository
+from src.apikeys.schemas import (
+    ApiKeyCreate,
+    ApiKeyCreatedResponse,
+    ApiKeyResponse,
+    ApiKeyUpdate,
+    PaginatedApiKeyResponse,
+)
+from src.apikeys.service import ApiKeyService
+from src.auth.dependencies import AdminUserDep
+from src.database import AsyncSessionDep
+
+router = APIRouter()
+
+
+@router.post("", status_code=status.HTTP_201_CREATED)
+async def create_api_key(
+    data: ApiKeyCreate,
+    session: AsyncSessionDep,
+    admin: AdminUserDep,
+) -> ApiKeyCreatedResponse:
+    """
+    Create a new API key (admin only).
+
+    The full API key is only returned once in this response.
+    Store it securely as it cannot be retrieved again.
+    """
+    service = ApiKeyService(session)
+    api_key, raw_key = await service.create_key(
+        user_id=admin.id,
+        name=data.name,
+        scopes=data.scopes,
+        expires_at=data.expires_at,
+    )
+
+    return ApiKeyCreatedResponse(
+        id=api_key.id,
+        name=api_key.name,
+        key=raw_key,
+        key_prefix=api_key.key_prefix,
+        scopes=api_key.scopes,
+        is_active=api_key.is_active,
+        created_at=api_key.created_at,
+        expires_at=api_key.expires_at,
+    )
+
+
+@router.get("")
+async def list_api_keys(
+    session: AsyncSessionDep,
+    admin: AdminUserDep,
+    page: int = Query(1, ge=1),
+    limit: int = Query(20, ge=1, le=100),
+) -> PaginatedApiKeyResponse:
+    """List all API keys for the current admin (paginated)."""
+    repo = ApiKeyRepository(session)
+    offset = (page - 1) * limit
+
+    keys = await repo.get_user_keys(admin.id, offset=offset, limit=limit)
+    total = await repo.count_user_keys(admin.id)
+
+    items = [ApiKeyResponse.model_validate(k) for k in keys]
+    return PaginatedApiKeyResponse.create(items, total, page, limit)
+
+
+@router.get("/{api_key_id}")
+async def get_api_key(
+    api_key_id: UUID,
+    session: AsyncSessionDep,
+    admin: AdminUserDep,
+) -> ApiKeyResponse:
+    """Get details of a specific API key."""
+    repo = ApiKeyRepository(session)
+    api_key = await repo.get_by_id(api_key_id)
+
+    if api_key is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="API key not found",
+        )
+
+    # Ensure the key belongs to this admin
+    if api_key.user_id != admin.id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Access denied",
+        )
+
+    return ApiKeyResponse.model_validate(api_key)
+
+
+@router.patch("/{api_key_id}")
+async def update_api_key(
+    api_key_id: UUID,
+    data: ApiKeyUpdate,
+    session: AsyncSessionDep,
+    admin: AdminUserDep,
+) -> ApiKeyResponse:
+    """Update an API key (name, scopes, or active status)."""
+    repo = ApiKeyRepository(session)
+    api_key = await repo.get_by_id(api_key_id)
+
+    if api_key is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="API key not found",
+        )
+
+    # Ensure the key belongs to this admin
+    if api_key.user_id != admin.id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Access denied",
+        )
+
+    # Validate scopes if provided
+    if data.scopes is not None:
+        from src.apikeys.schemas import VALID_SCOPES
+
+        data.scopes = [s for s in data.scopes if s in VALID_SCOPES]
+
+    api_key = await repo.update(api_key, data)
+    return ApiKeyResponse.model_validate(api_key)
+
+
+@router.delete("/{api_key_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_api_key(
+    api_key_id: UUID,
+    session: AsyncSessionDep,
+    admin: AdminUserDep,
+) -> None:
+    """Delete (revoke) an API key."""
+    repo = ApiKeyRepository(session)
+    api_key = await repo.get_by_id(api_key_id)
+
+    if api_key is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="API key not found",
+        )
+
+    # Ensure the key belongs to this admin
+    if api_key.user_id != admin.id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Access denied",
+        )
+
+    await repo.delete(api_key)

--- a/backend/src/apikeys/schemas.py
+++ b/backend/src/apikeys/schemas.py
@@ -1,0 +1,85 @@
+"""API Key schemas for request/response models."""
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+# Available scopes for API keys
+VALID_SCOPES = [
+    "feedback:read",
+    "feedback:write",
+    "admin:*",
+]
+
+
+class ApiKeyCreate(BaseModel):
+    """Schema for creating an API key."""
+
+    name: str = Field(..., min_length=1, max_length=255)
+    scopes: list[str] = Field(default_factory=list)
+    expires_at: datetime | None = None
+
+
+class ApiKeyResponse(BaseModel):
+    """Schema for API key response (without the actual key)."""
+
+    id: UUID
+    name: str
+    key_prefix: str
+    scopes: list[str]
+    is_active: bool
+    created_at: datetime
+    last_used_at: datetime | None
+    expires_at: datetime | None
+
+    model_config = {"from_attributes": True}
+
+
+class ApiKeyCreatedResponse(BaseModel):
+    """Schema for API key creation response (includes the full key, shown only once)."""
+
+    id: UUID
+    name: str
+    key: str  # The full API key, shown only once
+    key_prefix: str
+    scopes: list[str]
+    is_active: bool
+    created_at: datetime
+    expires_at: datetime | None
+
+
+class ApiKeyUpdate(BaseModel):
+    """Schema for updating an API key."""
+
+    name: str | None = Field(None, min_length=1, max_length=255)
+    scopes: list[str] | None = None
+    is_active: bool | None = None
+
+
+class PaginatedApiKeyResponse(BaseModel):
+    """Paginated response for API keys."""
+
+    items: list[ApiKeyResponse]
+    total: int
+    page: int
+    limit: int
+    total_pages: int
+
+    @classmethod
+    def create(
+        cls,
+        items: list[ApiKeyResponse],
+        total: int,
+        page: int,
+        limit: int,
+    ) -> "PaginatedApiKeyResponse":
+        """Create paginated response."""
+        total_pages = (total + limit - 1) // limit if limit > 0 else 0
+        return cls(
+            items=items,
+            total=total,
+            page=page,
+            limit=limit,
+            total_pages=total_pages,
+        )

--- a/backend/src/apikeys/service.py
+++ b/backend/src/apikeys/service.py
@@ -1,0 +1,123 @@
+"""API Key service for key generation and validation."""
+
+import hashlib
+import secrets
+from datetime import UTC, datetime
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.apikeys.models import ApiKey
+from src.apikeys.repository import ApiKeyRepository
+from src.apikeys.schemas import VALID_SCOPES
+
+
+class ApiKeyService:
+    """Service for API key operations."""
+
+    # Key format: homerp_<32 random bytes as base64>
+    KEY_PREFIX = "homerp_"
+    KEY_BYTES = 32
+
+    def __init__(self, session: AsyncSession):
+        self.session = session
+        self.repository = ApiKeyRepository(session)
+
+    @staticmethod
+    def generate_key() -> str:
+        """Generate a new random API key."""
+        random_bytes = secrets.token_urlsafe(ApiKeyService.KEY_BYTES)
+        return f"{ApiKeyService.KEY_PREFIX}{random_bytes}"
+
+    @staticmethod
+    def hash_key(key: str) -> str:
+        """Hash an API key using SHA-256."""
+        return hashlib.sha256(key.encode()).hexdigest()
+
+    @staticmethod
+    def get_key_prefix(key: str) -> str:
+        """Get the first 8 characters after the prefix for identification."""
+        # Remove the "homerp_" prefix and take first 8 chars
+        if key.startswith(ApiKeyService.KEY_PREFIX):
+            return key[
+                len(ApiKeyService.KEY_PREFIX) : len(ApiKeyService.KEY_PREFIX) + 8
+            ]
+        return key[:8]
+
+    @staticmethod
+    def validate_scopes(scopes: list[str]) -> list[str]:
+        """Validate and filter scopes to only valid ones."""
+        return [s for s in scopes if s in VALID_SCOPES]
+
+    async def create_key(
+        self,
+        user_id: UUID,
+        name: str,
+        scopes: list[str],
+        expires_at: datetime | None = None,
+    ) -> tuple[ApiKey, str]:
+        """
+        Create a new API key.
+
+        Returns the created ApiKey model and the raw key (shown only once).
+        """
+        # Generate the key
+        raw_key = self.generate_key()
+        key_hash = self.hash_key(raw_key)
+        key_prefix = self.get_key_prefix(raw_key)
+
+        # Validate scopes
+        valid_scopes = self.validate_scopes(scopes)
+
+        # Create the API key in the database
+        api_key = await self.repository.create(
+            user_id=user_id,
+            name=name,
+            key_hash=key_hash,
+            key_prefix=key_prefix,
+            scopes=valid_scopes,
+            expires_at=expires_at,
+        )
+
+        return api_key, raw_key
+
+    async def validate_key(self, raw_key: str) -> ApiKey | None:
+        """
+        Validate an API key and return the associated ApiKey if valid.
+
+        Returns None if the key is invalid, inactive, or expired.
+        """
+        key_hash = self.hash_key(raw_key)
+        api_key = await self.repository.get_by_hash(key_hash)
+
+        if api_key is None:
+            return None
+
+        # Check if key is active
+        if not api_key.is_active:
+            return None
+
+        # Check if key is expired
+        if api_key.expires_at is not None and api_key.expires_at < datetime.now(UTC):
+            return None
+
+        # Update last_used_at
+        await self.repository.update_last_used(api_key)
+
+        return api_key
+
+    def has_scope(self, api_key: ApiKey, required_scope: str) -> bool:
+        """
+        Check if an API key has the required scope.
+
+        Supports wildcard scopes (e.g., "admin:*" matches "admin:read").
+        """
+        if "admin:*" in api_key.scopes:
+            return True
+
+        if required_scope in api_key.scopes:
+            return True
+
+        # Check for wildcard match
+        scope_prefix = required_scope.split(":")[0]
+        return f"{scope_prefix}:*" in api_key.scopes

--- a/backend/src/auth/dependencies.py
+++ b/backend/src/auth/dependencies.py
@@ -1,35 +1,51 @@
 from typing import Annotated
 from uuid import UUID
 
-from fastapi import Depends, HTTPException, status
+from fastapi import Depends, Header, HTTPException, Request, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
+from src.apikeys.models import ApiKey
+from src.apikeys.service import ApiKeyService
 from src.auth.service import AuthService, get_auth_service
 from src.database import AsyncSessionDep
 from src.users.models import User
 from src.users.repository import UserRepository
 
-# HTTP Bearer token security
-security = HTTPBearer()
+# HTTP Bearer token security (auto_error=False to allow API key fallback)
+security = HTTPBearer(auto_error=False)
 
 
 async def get_current_user_id(
-    credentials: Annotated[HTTPAuthorizationCredentials, Depends(security)],
+    credentials: Annotated[HTTPAuthorizationCredentials | None, Depends(security)],
     auth_service: Annotated[AuthService, Depends(get_auth_service)],
+    session: AsyncSessionDep,
+    x_api_key: str | None = Header(None, alias="X-API-Key"),
 ) -> UUID:
     """
-    Get the current user ID from the JWT token.
+    Get the current user ID from the JWT token or API key.
 
-    Raises HTTPException if token is invalid.
+    Supports both Bearer token and X-API-Key header authentication.
+    Raises HTTPException if neither is valid.
     """
-    user_id = auth_service.verify_token(credentials.credentials)
-    if user_id is None:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid or expired token",
-            headers={"WWW-Authenticate": "Bearer"},
-        )
-    return user_id
+    # Try Bearer token first
+    if credentials is not None:
+        user_id = auth_service.verify_token(credentials.credentials)
+        if user_id is not None:
+            return user_id
+
+    # Try API key
+    if x_api_key is not None:
+        api_key_service = ApiKeyService(session)
+        api_key = await api_key_service.validate_key(x_api_key)
+        if api_key is not None:
+            return api_key.user_id
+
+    # Neither worked
+    raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Invalid or expired authentication",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
 
 
 async def get_current_user(
@@ -74,3 +90,55 @@ async def get_admin_user(
 
 
 AdminUserDep = Annotated[User, Depends(get_admin_user)]
+
+
+# API Key specific dependencies for scope-protected endpoints
+async def get_api_key_from_header(
+    session: AsyncSessionDep,
+    x_api_key: str | None = Header(None, alias="X-API-Key"),
+) -> ApiKey | None:
+    """
+    Get the API key from the X-API-Key header if present.
+
+    Returns None if no API key header or if the key is invalid.
+    """
+    if x_api_key is None:
+        return None
+
+    api_key_service = ApiKeyService(session)
+    return await api_key_service.validate_key(x_api_key)
+
+
+ApiKeyDep = Annotated[ApiKey | None, Depends(get_api_key_from_header)]
+
+
+def require_scope(scope: str):
+    """
+    Dependency factory to require a specific scope for API key authentication.
+
+    For Bearer token auth, this check is skipped (users have all permissions).
+    For API key auth, the key must have the required scope.
+    """
+
+    async def check_scope(
+        request: Request,
+        api_key: ApiKeyDep,
+        credentials: Annotated[HTTPAuthorizationCredentials | None, Depends(security)],
+    ) -> None:
+        # If authenticated via Bearer token, allow (users have full access)
+        if credentials is not None:
+            return
+
+        # If authenticated via API key, check scope
+        if api_key is not None:
+            api_key_service = ApiKeyService(request.state.session)
+            if api_key_service.has_scope(api_key, scope):
+                return
+
+        # No valid authentication with required scope
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"Insufficient permissions. Required scope: {scope}",
+        )
+
+    return check_scope

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -43,6 +43,7 @@ def create_app() -> FastAPI:
 
     # Include routers
     from src.admin.router import router as admin_router
+    from src.apikeys.router import router as apikeys_router
     from src.auth.router import router as auth_router
     from src.billing.router import router as billing_router
     from src.categories.router import router as categories_router
@@ -54,6 +55,7 @@ def create_app() -> FastAPI:
     from src.webhooks.router import router as webhooks_router
 
     app.include_router(admin_router, prefix="/api/v1/admin", tags=["admin"])
+    app.include_router(apikeys_router, prefix="/api/v1/admin/apikeys", tags=["apikeys"])
     app.include_router(auth_router, prefix="/api/v1/auth", tags=["auth"])
     app.include_router(billing_router, prefix="/api/v1/billing", tags=["billing"])
     app.include_router(feedback_router, prefix="/api/v1/feedback", tags=["feedback"])

--- a/backend/src/users/models.py
+++ b/backend/src/users/models.py
@@ -76,6 +76,9 @@ class User(Base):
     purge_recommendations: Mapped[list["PurgeRecommendation"]] = relationship(
         back_populates="user", cascade="all, delete-orphan"
     )
+    api_keys: Mapped[list["ApiKey"]] = relationship(
+        back_populates="user", cascade="all, delete-orphan"
+    )
 
     __table_args__ = (
         # Unique constraint on oauth_provider + oauth_id
@@ -84,6 +87,7 @@ class User(Base):
 
 
 # Import at bottom to avoid circular imports
+from src.apikeys.models import ApiKey  # noqa: E402
 from src.billing.models import CreditTransaction  # noqa: E402
 from src.categories.models import Category  # noqa: E402
 from src.feedback.models import Feedback  # noqa: E402

--- a/backend/tests/apikeys/__init__.py
+++ b/backend/tests/apikeys/__init__.py
@@ -1,0 +1,1 @@
+"""API Keys tests."""

--- a/backend/tests/apikeys/test_apikeys_router.py
+++ b/backend/tests/apikeys/test_apikeys_router.py
@@ -1,0 +1,461 @@
+"""HTTP integration tests for API keys router."""
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.apikeys.models import ApiKey
+from src.apikeys.service import ApiKeyService
+from src.users.models import User
+
+
+@pytest.fixture
+async def test_api_key(
+    async_session: AsyncSession, admin_user: User
+) -> tuple[ApiKey, str]:
+    """Create a test API key and return both the model and raw key."""
+    service = ApiKeyService(async_session)
+    api_key, raw_key = await service.create_key(
+        user_id=admin_user.id,
+        name="Test API Key",
+        scopes=["feedback:read", "feedback:write"],
+        expires_at=None,
+    )
+    return api_key, raw_key
+
+
+@pytest.fixture
+async def expired_api_key(
+    async_session: AsyncSession, admin_user: User
+) -> tuple[ApiKey, str]:
+    """Create an expired API key."""
+    service = ApiKeyService(async_session)
+    api_key, raw_key = await service.create_key(
+        user_id=admin_user.id,
+        name="Expired API Key",
+        scopes=["feedback:read"],
+        expires_at=datetime.now(UTC) - timedelta(days=1),
+    )
+    return api_key, raw_key
+
+
+class TestCreateApiKeyEndpoint:
+    """Tests for POST /api/v1/admin/apikeys."""
+
+    async def test_create_api_key_as_admin(self, admin_client: AsyncClient):
+        """Test creating an API key as admin."""
+        response = await admin_client.post(
+            "/api/v1/admin/apikeys",
+            json={
+                "name": "My API Key",
+                "scopes": ["feedback:read", "feedback:write"],
+            },
+        )
+
+        assert response.status_code == 201
+        data = response.json()
+        assert data["name"] == "My API Key"
+        assert "key" in data  # Full key is only returned once
+        assert data["key"].startswith("homerp_")
+        assert "key_prefix" in data
+        assert data["scopes"] == ["feedback:read", "feedback:write"]
+        assert data["is_active"] is True
+
+    async def test_create_api_key_with_expiration(self, admin_client: AsyncClient):
+        """Test creating an API key with expiration date."""
+        expires_at = (datetime.now(UTC) + timedelta(days=30)).isoformat()
+        response = await admin_client.post(
+            "/api/v1/admin/apikeys",
+            json={
+                "name": "Expiring Key",
+                "scopes": ["feedback:read"],
+                "expires_at": expires_at,
+            },
+        )
+
+        assert response.status_code == 201
+        data = response.json()
+        assert data["expires_at"] is not None
+
+    async def test_create_api_key_invalid_scopes_filtered(
+        self, admin_client: AsyncClient
+    ):
+        """Test that invalid scopes are filtered out."""
+        response = await admin_client.post(
+            "/api/v1/admin/apikeys",
+            json={
+                "name": "Key with Invalid Scopes",
+                "scopes": ["feedback:read", "invalid:scope", "admin:*"],
+            },
+        )
+
+        assert response.status_code == 201
+        data = response.json()
+        # Invalid scope should be filtered out
+        assert "invalid:scope" not in data["scopes"]
+        assert "feedback:read" in data["scopes"]
+        assert "admin:*" in data["scopes"]
+
+    async def test_create_api_key_as_non_admin(self, authenticated_client: AsyncClient):
+        """Test that non-admin gets 403."""
+        response = await authenticated_client.post(
+            "/api/v1/admin/apikeys",
+            json={
+                "name": "My API Key",
+                "scopes": ["feedback:read"],
+            },
+        )
+
+        assert response.status_code == 403
+
+    async def test_create_api_key_unauthenticated(
+        self, unauthenticated_client: AsyncClient
+    ):
+        """Test that unauthenticated request returns 401."""
+        response = await unauthenticated_client.post(
+            "/api/v1/admin/apikeys",
+            json={
+                "name": "My API Key",
+                "scopes": ["feedback:read"],
+            },
+        )
+
+        assert response.status_code == 401
+
+
+class TestListApiKeysEndpoint:
+    """Tests for GET /api/v1/admin/apikeys."""
+
+    async def test_list_api_keys_as_admin(
+        self, admin_client: AsyncClient, test_api_key: tuple[ApiKey, str]
+    ):
+        """Test listing API keys as admin."""
+        response = await admin_client.get("/api/v1/admin/apikeys")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "items" in data
+        assert "total" in data
+        assert len(data["items"]) >= 1
+        # Key should NOT include the full key
+        assert "key" not in data["items"][0]
+        assert "key_prefix" in data["items"][0]
+
+    async def test_list_api_keys_pagination(self, admin_client: AsyncClient):
+        """Test pagination of API keys."""
+        # Create multiple keys
+        for i in range(3):
+            await admin_client.post(
+                "/api/v1/admin/apikeys",
+                json={"name": f"Key {i}", "scopes": ["feedback:read"]},
+            )
+
+        response = await admin_client.get(
+            "/api/v1/admin/apikeys", params={"page": 1, "limit": 2}
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["items"]) <= 2
+
+    async def test_list_api_keys_as_non_admin(self, authenticated_client: AsyncClient):
+        """Test that non-admin gets 403."""
+        response = await authenticated_client.get("/api/v1/admin/apikeys")
+
+        assert response.status_code == 403
+
+
+class TestGetApiKeyEndpoint:
+    """Tests for GET /api/v1/admin/apikeys/{api_key_id}."""
+
+    async def test_get_api_key_as_admin(
+        self, admin_client: AsyncClient, test_api_key: tuple[ApiKey, str]
+    ):
+        """Test getting a specific API key as admin."""
+        api_key, _ = test_api_key
+        response = await admin_client.get(f"/api/v1/admin/apikeys/{api_key.id}")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["id"] == str(api_key.id)
+        assert data["name"] == api_key.name
+        # Full key should not be returned
+        assert "key" not in data
+
+    async def test_get_api_key_not_found(self, admin_client: AsyncClient):
+        """Test getting non-existent API key."""
+        response = await admin_client.get(f"/api/v1/admin/apikeys/{uuid.uuid4()}")
+
+        assert response.status_code == 404
+
+    async def test_get_api_key_as_non_admin(
+        self, authenticated_client: AsyncClient, test_api_key: tuple[ApiKey, str]
+    ):
+        """Test that non-admin gets 403."""
+        api_key, _ = test_api_key
+        response = await authenticated_client.get(f"/api/v1/admin/apikeys/{api_key.id}")
+
+        assert response.status_code == 403
+
+
+class TestUpdateApiKeyEndpoint:
+    """Tests for PATCH /api/v1/admin/apikeys/{api_key_id}."""
+
+    async def test_update_api_key_name(
+        self, admin_client: AsyncClient, test_api_key: tuple[ApiKey, str]
+    ):
+        """Test updating API key name."""
+        api_key, _ = test_api_key
+        response = await admin_client.patch(
+            f"/api/v1/admin/apikeys/{api_key.id}",
+            json={"name": "Updated Name"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["name"] == "Updated Name"
+
+    async def test_update_api_key_scopes(
+        self, admin_client: AsyncClient, test_api_key: tuple[ApiKey, str]
+    ):
+        """Test updating API key scopes."""
+        api_key, _ = test_api_key
+        response = await admin_client.patch(
+            f"/api/v1/admin/apikeys/{api_key.id}",
+            json={"scopes": ["admin:*"]},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["scopes"] == ["admin:*"]
+
+    async def test_deactivate_api_key(
+        self, admin_client: AsyncClient, test_api_key: tuple[ApiKey, str]
+    ):
+        """Test deactivating an API key."""
+        api_key, _ = test_api_key
+        response = await admin_client.patch(
+            f"/api/v1/admin/apikeys/{api_key.id}",
+            json={"is_active": False},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["is_active"] is False
+
+    async def test_update_api_key_not_found(self, admin_client: AsyncClient):
+        """Test updating non-existent API key."""
+        response = await admin_client.patch(
+            f"/api/v1/admin/apikeys/{uuid.uuid4()}",
+            json={"name": "New Name"},
+        )
+
+        assert response.status_code == 404
+
+    async def test_update_api_key_as_non_admin(
+        self, authenticated_client: AsyncClient, test_api_key: tuple[ApiKey, str]
+    ):
+        """Test that non-admin gets 403."""
+        api_key, _ = test_api_key
+        response = await authenticated_client.patch(
+            f"/api/v1/admin/apikeys/{api_key.id}",
+            json={"name": "Hacked"},
+        )
+
+        assert response.status_code == 403
+
+
+class TestDeleteApiKeyEndpoint:
+    """Tests for DELETE /api/v1/admin/apikeys/{api_key_id}."""
+
+    async def test_delete_api_key_as_admin(
+        self, admin_client: AsyncClient, test_api_key: tuple[ApiKey, str]
+    ):
+        """Test deleting an API key as admin."""
+        api_key, _ = test_api_key
+        response = await admin_client.delete(f"/api/v1/admin/apikeys/{api_key.id}")
+
+        assert response.status_code == 204
+
+        # Verify key is deleted
+        get_response = await admin_client.get(f"/api/v1/admin/apikeys/{api_key.id}")
+        assert get_response.status_code == 404
+
+    async def test_delete_api_key_not_found(self, admin_client: AsyncClient):
+        """Test deleting non-existent API key."""
+        response = await admin_client.delete(f"/api/v1/admin/apikeys/{uuid.uuid4()}")
+
+        assert response.status_code == 404
+
+    async def test_delete_api_key_as_non_admin(
+        self, authenticated_client: AsyncClient, test_api_key: tuple[ApiKey, str]
+    ):
+        """Test that non-admin gets 403."""
+        api_key, _ = test_api_key
+        response = await authenticated_client.delete(
+            f"/api/v1/admin/apikeys/{api_key.id}"
+        )
+
+        assert response.status_code == 403
+
+
+class TestApiKeyAuthenticationEndpoint:
+    """Tests for using API key authentication on endpoints."""
+
+    async def test_feedback_resolve_with_api_key(
+        self,
+        unauthenticated_client: AsyncClient,
+        test_api_key: tuple[ApiKey, str],
+        test_feedback,  # noqa: ANN001 - Feedback fixture
+    ):
+        """Test using API key to resolve feedback."""
+        _, raw_key = test_api_key
+        response = await unauthenticated_client.put(
+            f"/api/v1/feedback/admin/{test_feedback.id}/resolve",
+            headers={"X-API-Key": raw_key},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "resolved"
+
+    async def test_feedback_resolve_with_invalid_api_key(
+        self,
+        unauthenticated_client: AsyncClient,
+        test_feedback,  # noqa: ANN001 - Feedback fixture
+    ):
+        """Test using invalid API key."""
+        response = await unauthenticated_client.put(
+            f"/api/v1/feedback/admin/{test_feedback.id}/resolve",
+            headers={"X-API-Key": "invalid_key"},
+        )
+
+        assert response.status_code == 401
+
+    async def test_feedback_resolve_with_expired_api_key(
+        self,
+        unauthenticated_client: AsyncClient,
+        expired_api_key: tuple[ApiKey, str],
+        test_feedback,  # noqa: ANN001 - Feedback fixture
+    ):
+        """Test using expired API key."""
+        _, raw_key = expired_api_key
+        response = await unauthenticated_client.put(
+            f"/api/v1/feedback/admin/{test_feedback.id}/resolve",
+            headers={"X-API-Key": raw_key},
+        )
+
+        assert response.status_code == 401
+
+    async def test_feedback_resolve_with_deactivated_api_key(
+        self,
+        async_session: AsyncSession,
+        admin_user: User,
+        unauthenticated_client: AsyncClient,
+        test_feedback,  # noqa: ANN001 - Feedback fixture
+    ):
+        """Test using deactivated API key."""
+        # Create and immediately deactivate a key
+        service = ApiKeyService(async_session)
+        api_key, raw_key = await service.create_key(
+            user_id=admin_user.id,
+            name="Inactive Key",
+            scopes=["feedback:read", "feedback:write"],
+        )
+        # Deactivate the key in the database
+        api_key.is_active = False
+        await async_session.commit()
+
+        # Try to use it
+        response = await unauthenticated_client.put(
+            f"/api/v1/feedback/admin/{test_feedback.id}/resolve",
+            headers={"X-API-Key": raw_key},
+        )
+
+        assert response.status_code == 401
+
+
+class TestApiKeyService:
+    """Unit tests for ApiKeyService."""
+
+    async def test_key_generation_format(self, async_session: AsyncSession):
+        """Test that generated keys have correct format."""
+        service = ApiKeyService(async_session)
+        key = service.generate_key()
+
+        assert key.startswith("homerp_")
+        assert len(key) > 20  # Should be reasonably long
+
+    async def test_key_hashing_is_deterministic(self, async_session: AsyncSession):
+        """Test that hashing the same key produces same hash."""
+        service = ApiKeyService(async_session)
+        key = "homerp_test_key_12345"
+
+        hash1 = service.hash_key(key)
+        hash2 = service.hash_key(key)
+
+        assert hash1 == hash2
+
+    async def test_different_keys_have_different_hashes(
+        self, async_session: AsyncSession
+    ):
+        """Test that different keys produce different hashes."""
+        service = ApiKeyService(async_session)
+
+        hash1 = service.hash_key("homerp_key1")
+        hash2 = service.hash_key("homerp_key2")
+
+        assert hash1 != hash2
+
+    async def test_scope_validation(self, async_session: AsyncSession):
+        """Test that invalid scopes are filtered."""
+        service = ApiKeyService(async_session)
+
+        valid = service.validate_scopes(
+            ["feedback:read", "invalid:scope", "feedback:write"]
+        )
+
+        assert "feedback:read" in valid
+        assert "feedback:write" in valid
+        assert "invalid:scope" not in valid
+
+    async def test_has_scope_direct_match(
+        self, async_session: AsyncSession, admin_user: User
+    ):
+        """Test scope checking with direct match."""
+        service = ApiKeyService(async_session)
+        api_key, _ = await service.create_key(
+            user_id=admin_user.id,
+            name="Test",
+            scopes=["feedback:read"],
+        )
+
+        assert service.has_scope(api_key, "feedback:read") is True
+        assert service.has_scope(api_key, "feedback:write") is False
+
+    async def test_has_scope_admin_wildcard(
+        self, async_session: AsyncSession, admin_user: User
+    ):
+        """Test that admin:* grants all permissions."""
+        service = ApiKeyService(async_session)
+        api_key, _ = await service.create_key(
+            user_id=admin_user.id,
+            name="Test",
+            scopes=["admin:*"],
+        )
+
+        assert service.has_scope(api_key, "feedback:read") is True
+        assert service.has_scope(api_key, "feedback:write") is True
+        assert service.has_scope(api_key, "anything:else") is True
+
+    async def test_key_prefix_extraction(self, async_session: AsyncSession):
+        """Test key prefix extraction."""
+        service = ApiKeyService(async_session)
+        key = "homerp_abcdefgh12345678"
+
+        prefix = service.get_key_prefix(key)
+
+        assert prefix == "abcdefgh"  # First 8 chars after prefix

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -407,6 +407,41 @@
       "creditsPurchased": "Credits Purchased",
       "pendingFeedback": "Pending Feedback",
       "active": "active"
+    },
+    "apiKeys": {
+      "title": "API Keys",
+      "description": "Manage API keys for external integrations and automation",
+      "createApiKey": "Create API Key",
+      "editApiKey": "Edit API Key",
+      "deleteApiKey": "Delete API Key",
+      "deleteConfirm": "Are you sure you want to delete this API key? Any systems using this key will lose access immediately.",
+      "name": "Name",
+      "namePlaceholder": "e.g., GitHub Actions",
+      "key": "API Key",
+      "keyPrefix": "Key Prefix",
+      "scopes": "Scopes",
+      "scopesHelp": "Select which permissions this API key should have",
+      "isActive": "Active",
+      "expiresAt": "Expires At",
+      "expiresAtHelp": "Leave empty for no expiration",
+      "lastUsed": "Last Used",
+      "createdAt": "Created At",
+      "never": "Never",
+      "noExpiration": "No expiration",
+      "noApiKeys": "No API keys created yet",
+      "noApiKeysDescription": "Create an API key to enable external integrations",
+      "keyCreated": "API Key Created",
+      "keyCreatedWarning": "This is the only time you will see this key. Copy it now and store it securely.",
+      "copyKey": "Copy Key",
+      "keyCopied": "API key copied to clipboard",
+      "apiKeyCreated": "API key created successfully",
+      "apiKeyUpdated": "API key updated successfully",
+      "apiKeyDeleted": "API key deleted successfully",
+      "availableScopes": {
+        "feedback:read": "Read feedback status",
+        "feedback:write": "Update feedback status (resolve)",
+        "admin:*": "Full admin access"
+      }
     }
   },
   "webhooks": {

--- a/frontend/src/app/(dashboard)/admin/api-keys/page.tsx
+++ b/frontend/src/app/(dashboard)/admin/api-keys/page.tsx
@@ -1,0 +1,651 @@
+"use client";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useAuth } from "@/context/auth-context";
+import {
+  apiKeysApi,
+  ApiKeyCreate,
+  ApiKeyCreatedResponse,
+  ApiKeyResponse,
+  ApiKeyUpdate,
+} from "@/lib/api/api-client";
+import { formatDateTime } from "@/lib/utils";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  ArrowLeft,
+  Check,
+  Copy,
+  Key,
+  Loader2,
+  Pencil,
+  Plus,
+  Trash2,
+  X,
+} from "lucide-react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
+
+const AVAILABLE_SCOPES = ["feedback:read", "feedback:write", "admin:*"];
+
+type ApiKeyFormData = {
+  name: string;
+  scopes: string[];
+  expires_at: string;
+};
+
+function ApiKeyFormDialog({
+  open,
+  onClose,
+  apiKey,
+  onSave,
+  isSaving,
+}: {
+  open: boolean;
+  onClose: () => void;
+  apiKey?: ApiKeyResponse;
+  onSave: (data: ApiKeyCreate | ApiKeyUpdate) => void;
+  isSaving: boolean;
+}) {
+  const t = useTranslations("admin.apiKeys");
+  const [formData, setFormData] = useState<ApiKeyFormData>({
+    name: apiKey?.name ?? "",
+    scopes: apiKey?.scopes ?? [],
+    expires_at: apiKey?.expires_at
+      ? new Date(apiKey.expires_at).toISOString().slice(0, 16)
+      : "",
+  });
+
+  useEffect(() => {
+    if (apiKey) {
+      setFormData({
+        name: apiKey.name,
+        scopes: apiKey.scopes,
+        expires_at: apiKey.expires_at
+          ? new Date(apiKey.expires_at).toISOString().slice(0, 16)
+          : "",
+      });
+    } else {
+      setFormData({
+        name: "",
+        scopes: [],
+        expires_at: "",
+      });
+    }
+  }, [apiKey, open]);
+
+  const toggleScope = (scope: string) => {
+    setFormData((prev) => ({
+      ...prev,
+      scopes: prev.scopes.includes(scope)
+        ? prev.scopes.filter((s) => s !== scope)
+        : [...prev.scopes, scope],
+    }));
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const data: ApiKeyCreate | ApiKeyUpdate = {
+      name: formData.name,
+      scopes: formData.scopes,
+      expires_at: formData.expires_at || null,
+    };
+    onSave(data);
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(isOpen: boolean) => !isOpen && onClose()}
+    >
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>
+            {apiKey ? t("editApiKey") : t("createApiKey")}
+          </DialogTitle>
+          <DialogDescription>
+            {apiKey ? t("description") : t("description")}
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit}>
+          <div className="space-y-4 py-4">
+            <div className="space-y-2">
+              <Label htmlFor="name">{t("name")}</Label>
+              <Input
+                id="name"
+                data-testid="api-key-name-input"
+                value={formData.name}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  setFormData({ ...formData, name: e.target.value })
+                }
+                placeholder={t("namePlaceholder")}
+                required
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label>{t("scopes")}</Label>
+              <p className="text-xs text-muted-foreground">{t("scopesHelp")}</p>
+              <div className="space-y-2">
+                {AVAILABLE_SCOPES.map((scope) => (
+                  <div key={scope} className="flex items-center space-x-2">
+                    <input
+                      type="checkbox"
+                      id={`scope-${scope}`}
+                      data-testid={`scope-checkbox-${scope}`}
+                      checked={formData.scopes.includes(scope)}
+                      onChange={() => toggleScope(scope)}
+                      className="h-4 w-4 rounded border-gray-300"
+                    />
+                    <Label htmlFor={`scope-${scope}`} className="font-normal">
+                      <code className="rounded bg-muted px-1 py-0.5 text-sm">
+                        {scope}
+                      </code>
+                      <span className="ml-2 text-xs text-muted-foreground">
+                        {t(
+                          `availableScopes.${scope.replace(":", "_").replace("*", "star")}` as "availableScopes.feedback_read"
+                        )}
+                      </span>
+                    </Label>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="expires_at">{t("expiresAt")}</Label>
+              <Input
+                id="expires_at"
+                type="datetime-local"
+                data-testid="api-key-expires-input"
+                value={formData.expires_at}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  setFormData({ ...formData, expires_at: e.target.value })
+                }
+              />
+              <p className="text-xs text-muted-foreground">
+                {t("expiresAtHelp")}
+              </p>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={onClose}>
+              {t("../common.cancel")}
+            </Button>
+            <Button
+              type="submit"
+              disabled={isSaving}
+              data-testid="save-api-key-button"
+            >
+              {isSaving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              {apiKey ? t("../common.save") : t("createApiKey")}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function KeyCreatedDialog({
+  open,
+  onClose,
+  createdKey,
+}: {
+  open: boolean;
+  onClose: () => void;
+  createdKey: ApiKeyCreatedResponse | null;
+}) {
+  const t = useTranslations("admin.apiKeys");
+  const [copied, setCopied] = useState(false);
+
+  const copyToClipboard = async () => {
+    if (createdKey?.key) {
+      await navigator.clipboard.writeText(createdKey.key);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(isOpen: boolean) => !isOpen && onClose()}
+    >
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Key className="h-5 w-5 text-green-500" />
+            {t("keyCreated")}
+          </DialogTitle>
+          <DialogDescription className="text-amber-600 dark:text-amber-400">
+            {t("keyCreatedWarning")}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4 py-4">
+          <div className="space-y-2">
+            <Label>{t("key")}</Label>
+            <div className="flex items-center gap-2">
+              <code className="flex-1 overflow-x-auto rounded bg-muted p-3 text-sm">
+                {createdKey?.key}
+              </code>
+              <Button
+                variant="outline"
+                size="icon"
+                onClick={copyToClipboard}
+                data-testid="copy-api-key-button"
+              >
+                {copied ? (
+                  <Check className="h-4 w-4 text-green-500" />
+                ) : (
+                  <Copy className="h-4 w-4" />
+                )}
+              </Button>
+            </div>
+          </div>
+          <div className="grid grid-cols-2 gap-4 text-sm">
+            <div>
+              <span className="text-muted-foreground">{t("name")}:</span>
+              <p className="font-medium">{createdKey?.name}</p>
+            </div>
+            <div>
+              <span className="text-muted-foreground">{t("scopes")}:</span>
+              <p className="font-medium">
+                {createdKey?.scopes.join(", ") || "None"}
+              </p>
+            </div>
+          </div>
+        </div>
+        <DialogFooter>
+          <Button onClick={onClose} data-testid="close-key-dialog-button">
+            {t("../common.close")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default function AdminApiKeysPage() {
+  const t = useTranslations("admin.apiKeys");
+  const tCommon = useTranslations("common");
+  const { user, isLoading: authLoading } = useAuth();
+  const router = useRouter();
+  const queryClient = useQueryClient();
+
+  const [editingKey, setEditingKey] = useState<ApiKeyResponse | null>(null);
+  const [isCreateOpen, setIsCreateOpen] = useState(false);
+  const [deleteKeyId, setDeleteKeyId] = useState<string | null>(null);
+  const [createdKey, setCreatedKey] = useState<ApiKeyCreatedResponse | null>(
+    null
+  );
+  const [page, setPage] = useState(1);
+
+  const { data: apiKeysData, isLoading: apiKeysLoading } = useQuery({
+    queryKey: ["admin-api-keys", page],
+    queryFn: () => apiKeysApi.list(page, 20),
+    enabled: !!user?.is_admin,
+  });
+
+  const createMutation = useMutation({
+    mutationFn: (data: ApiKeyCreate) => apiKeysApi.create(data),
+    onSuccess: (response) => {
+      queryClient.invalidateQueries({ queryKey: ["admin-api-keys"] });
+      setIsCreateOpen(false);
+      setCreatedKey(response);
+    },
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: ({ id, data }: { id: string; data: ApiKeyUpdate }) =>
+      apiKeysApi.update(id, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["admin-api-keys"] });
+      setEditingKey(null);
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => apiKeysApi.delete(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["admin-api-keys"] });
+      setDeleteKeyId(null);
+    },
+  });
+
+  useEffect(() => {
+    if (!authLoading && (!user || !user.is_admin)) {
+      router.push("/dashboard");
+    }
+  }, [user, authLoading, router]);
+
+  if (authLoading || !user?.is_admin) {
+    return (
+      <div className="flex h-64 items-center justify-center">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  const handleCreate = (data: ApiKeyCreate | ApiKeyUpdate) => {
+    createMutation.mutate(data as ApiKeyCreate);
+  };
+
+  const handleUpdate = (data: ApiKeyCreate | ApiKeyUpdate) => {
+    if (editingKey) {
+      updateMutation.mutate({ id: editingKey.id, data: data as ApiKeyUpdate });
+    }
+  };
+
+  const handleDelete = () => {
+    if (deleteKeyId) {
+      deleteMutation.mutate(deleteKeyId);
+    }
+  };
+
+  const apiKeys = apiKeysData?.items ?? [];
+  const totalPages = apiKeysData?.total_pages ?? 1;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-4">
+        <Link href="/admin">
+          <Button
+            variant="ghost"
+            size="icon"
+            data-testid="back-to-admin-button"
+          >
+            <ArrowLeft className="h-5 w-5" />
+          </Button>
+        </Link>
+        <div className="flex-1">
+          <h1 className="text-2xl font-bold tracking-tight md:text-3xl">
+            {t("title")}
+          </h1>
+          <p className="mt-1 text-muted-foreground">{t("description")}</p>
+        </div>
+        <Button
+          onClick={() => setIsCreateOpen(true)}
+          className="gap-2"
+          data-testid="create-api-key-button"
+        >
+          <Plus className="h-4 w-4" />
+          {t("createApiKey")}
+        </Button>
+      </div>
+
+      {apiKeysLoading ? (
+        <div className="flex h-32 items-center justify-center">
+          <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+        </div>
+      ) : (
+        <>
+          {/* Desktop Table View */}
+          <div className="hidden rounded-xl border bg-card md:block">
+            <div className="overflow-x-auto">
+              <table className="w-full">
+                <thead>
+                  <tr className="border-b text-left text-sm text-muted-foreground">
+                    <th className="px-4 py-3 font-medium">{t("name")}</th>
+                    <th className="px-4 py-3 font-medium">{t("keyPrefix")}</th>
+                    <th className="px-4 py-3 font-medium">{t("scopes")}</th>
+                    <th className="px-4 py-3 font-medium">{t("isActive")}</th>
+                    <th className="px-4 py-3 font-medium">{t("lastUsed")}</th>
+                    <th className="px-4 py-3 font-medium">{t("expiresAt")}</th>
+                    <th className="px-4 py-3 text-right font-medium">
+                      {tCommon("actions")}
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {apiKeys.map((key) => (
+                    <tr
+                      key={key.id}
+                      className="border-b last:border-0"
+                      data-testid={`api-key-row-${key.id}`}
+                    >
+                      <td className="px-4 py-3 font-medium">{key.name}</td>
+                      <td className="px-4 py-3 font-mono text-sm text-muted-foreground">
+                        {key.key_prefix}...
+                      </td>
+                      <td className="px-4 py-3">
+                        <div className="flex flex-wrap gap-1">
+                          {key.scopes.map((scope) => (
+                            <span
+                              key={scope}
+                              className="rounded-full bg-muted px-2 py-0.5 text-xs"
+                            >
+                              {scope}
+                            </span>
+                          ))}
+                        </div>
+                      </td>
+                      <td className="px-4 py-3">
+                        {key.is_active ? (
+                          <span className="inline-flex items-center gap-1 rounded-full bg-green-100 px-2 py-1 text-xs font-medium text-green-700 dark:bg-green-900 dark:text-green-200">
+                            <Check className="h-3 w-3" /> Active
+                          </span>
+                        ) : (
+                          <span className="inline-flex items-center gap-1 rounded-full bg-gray-100 px-2 py-1 text-xs font-medium text-gray-700 dark:bg-gray-700 dark:text-gray-200">
+                            <X className="h-3 w-3" /> Inactive
+                          </span>
+                        )}
+                      </td>
+                      <td className="px-4 py-3 text-sm text-muted-foreground">
+                        {key.last_used_at
+                          ? formatDateTime(key.last_used_at)
+                          : t("never")}
+                      </td>
+                      <td className="px-4 py-3 text-sm text-muted-foreground">
+                        {key.expires_at
+                          ? formatDateTime(key.expires_at)
+                          : t("noExpiration")}
+                      </td>
+                      <td className="px-4 py-3">
+                        <div className="flex justify-end gap-2">
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            onClick={() => setEditingKey(key)}
+                            data-testid={`edit-api-key-${key.id}`}
+                          >
+                            <Pencil className="h-4 w-4" />
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            onClick={() => setDeleteKeyId(key.id)}
+                            data-testid={`delete-api-key-${key.id}`}
+                          >
+                            <Trash2 className="h-4 w-4 text-destructive" />
+                          </Button>
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                  {apiKeys.length === 0 && (
+                    <tr>
+                      <td
+                        colSpan={7}
+                        className="px-4 py-8 text-center text-muted-foreground"
+                      >
+                        {t("noApiKeys")}
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          {/* Mobile Card View */}
+          <div className="space-y-3 md:hidden">
+            {apiKeys.map((key) => (
+              <div
+                key={key.id}
+                className="rounded-xl border bg-card p-4"
+                data-testid={`api-key-card-${key.id}`}
+              >
+                <div className="flex items-start justify-between">
+                  <div>
+                    <p className="font-medium">{key.name}</p>
+                    <p className="font-mono text-sm text-muted-foreground">
+                      {key.key_prefix}...
+                    </p>
+                  </div>
+                  {key.is_active ? (
+                    <span className="inline-flex items-center gap-1 rounded-full bg-green-100 px-2 py-1 text-xs font-medium text-green-700 dark:bg-green-900 dark:text-green-200">
+                      <Check className="h-3 w-3" /> Active
+                    </span>
+                  ) : (
+                    <span className="inline-flex items-center gap-1 rounded-full bg-gray-100 px-2 py-1 text-xs font-medium text-gray-700 dark:bg-gray-700 dark:text-gray-200">
+                      <X className="h-3 w-3" /> Inactive
+                    </span>
+                  )}
+                </div>
+                <div className="mt-2 flex flex-wrap gap-1">
+                  {key.scopes.map((scope) => (
+                    <span
+                      key={scope}
+                      className="rounded-full bg-muted px-2 py-0.5 text-xs"
+                    >
+                      {scope}
+                    </span>
+                  ))}
+                </div>
+                <div className="mt-2 text-xs text-muted-foreground">
+                  {t("lastUsed")}:{" "}
+                  {key.last_used_at
+                    ? formatDateTime(key.last_used_at)
+                    : t("never")}
+                </div>
+                <div className="mt-3 flex gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="flex-1"
+                    onClick={() => setEditingKey(key)}
+                  >
+                    <Pencil className="mr-1 h-4 w-4" />
+                    {tCommon("edit")}
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setDeleteKeyId(key.id)}
+                    className="text-destructive hover:text-destructive"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </div>
+              </div>
+            ))}
+            {apiKeys.length === 0 && (
+              <div className="rounded-xl border bg-card p-8 text-center text-muted-foreground">
+                {t("noApiKeys")}
+              </div>
+            )}
+          </div>
+
+          {/* Pagination */}
+          {totalPages > 1 && (
+            <div className="flex items-center justify-center gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+                disabled={page === 1}
+              >
+                {tCommon("previous")}
+              </Button>
+              <span className="text-sm text-muted-foreground">
+                {tCommon("page")} {page} {tCommon("of")} {totalPages}
+              </span>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+                disabled={page === totalPages}
+              >
+                {tCommon("next")}
+              </Button>
+            </div>
+          )}
+        </>
+      )}
+
+      {/* Create Dialog */}
+      <ApiKeyFormDialog
+        open={isCreateOpen}
+        onClose={() => setIsCreateOpen(false)}
+        onSave={handleCreate}
+        isSaving={createMutation.isPending}
+      />
+
+      {/* Edit Dialog */}
+      <ApiKeyFormDialog
+        open={!!editingKey}
+        onClose={() => setEditingKey(null)}
+        apiKey={editingKey ?? undefined}
+        onSave={handleUpdate}
+        isSaving={updateMutation.isPending}
+      />
+
+      {/* Key Created Dialog */}
+      <KeyCreatedDialog
+        open={!!createdKey}
+        onClose={() => setCreatedKey(null)}
+        createdKey={createdKey}
+      />
+
+      {/* Delete Confirmation */}
+      <AlertDialog
+        open={!!deleteKeyId}
+        onOpenChange={() => setDeleteKeyId(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t("deleteApiKey")}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {t("deleteConfirm")}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{tCommon("cancel")}</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDelete}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              data-testid="confirm-delete-api-key"
+            >
+              {deleteMutation.isPending && (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              )}
+              {tCommon("delete")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/frontend/src/app/(dashboard)/admin/page.tsx
+++ b/frontend/src/app/(dashboard)/admin/page.tsx
@@ -23,6 +23,7 @@ import {
   Clock,
   AlertCircle,
   ShoppingCart,
+  Key,
 } from "lucide-react";
 import Link from "next/link";
 import { Badge } from "@/components/ui/badge";
@@ -327,6 +328,13 @@ export default function AdminPage() {
                   icon={Webhook}
                   href="/admin/webhooks"
                   testId="quick-action-webhooks"
+                />
+                <QuickActionCard
+                  title={t("admin.apiKeys.title")}
+                  description={t("admin.apiKeys.description")}
+                  icon={Key}
+                  href="/admin/api-keys"
+                  testId="quick-action-api-keys"
                 />
               </div>
             </div>

--- a/frontend/src/lib/api/api-client.ts
+++ b/frontend/src/lib/api/api-client.ts
@@ -1185,6 +1185,67 @@ export type GenerateRecommendationsResponse = {
   credits_used: number;
 };
 
+// API Key Types
+export type ApiKeyResponse = {
+  id: string;
+  name: string;
+  key_prefix: string;
+  scopes: string[];
+  is_active: boolean;
+  created_at: string;
+  last_used_at: string | null;
+  expires_at: string | null;
+};
+
+export type ApiKeyCreatedResponse = {
+  id: string;
+  name: string;
+  key: string;
+  key_prefix: string;
+  scopes: string[];
+  is_active: boolean;
+  created_at: string;
+  expires_at: string | null;
+};
+
+export type ApiKeyCreate = {
+  name: string;
+  scopes: string[];
+  expires_at?: string | null;
+};
+
+export type ApiKeyUpdate = {
+  name?: string;
+  scopes?: string[];
+  is_active?: boolean;
+};
+
+// API Keys API
+export const apiKeysApi = {
+  list: (page = 1, limit = 20) =>
+    apiRequest<PaginatedResponse<ApiKeyResponse>>(
+      `/api/v1/admin/apikeys?page=${page}&limit=${limit}`
+    ),
+
+  get: (id: string) =>
+    apiRequest<ApiKeyResponse>(`/api/v1/admin/apikeys/${id}`),
+
+  create: (data: ApiKeyCreate) =>
+    apiRequest<ApiKeyCreatedResponse>("/api/v1/admin/apikeys", {
+      method: "POST",
+      body: data,
+    }),
+
+  update: (id: string, data: ApiKeyUpdate) =>
+    apiRequest<ApiKeyResponse>(`/api/v1/admin/apikeys/${id}`, {
+      method: "PATCH",
+      body: data,
+    }),
+
+  delete: (id: string) =>
+    apiRequest<void>(`/api/v1/admin/apikeys/${id}`, { method: "DELETE" }),
+};
+
 // Profile API
 export const profileApi = {
   getHobbyTypes: () =>


### PR DESCRIPTION
## Summary

Implements a complete API key authentication system for external tools like GitHub Actions to authenticate with the HomERP API. This enables automation scenarios like automatically resolving feedback when a related GitHub issue is closed.

### Key Features

- **API Key Management**: Full CRUD operations for API keys in admin panel
- **Secure Design**: Keys are hashed (SHA-256), displayed only once on creation
- **Scope-based Permissions**: `feedback:read`, `feedback:write`, `admin:*`
- **Dual Auth Support**: Both Bearer token and X-API-Key header work
- **GitHub Actions Integration**: Workflow to sync feedback status on issue close

### Changes

**Backend**
- New `apikeys` module with model, repository, service, schemas, and router
- Updated `auth/dependencies.py` to support API key authentication
- New `/api/v1/feedback/admin/{id}/resolve` endpoint
- Database migration with RLS policy for tenant isolation
- 30 tests covering all CRUD and authentication scenarios

**Frontend**
- New API key management page at `/admin/api-keys`
- One-time key display with copy button
- Scope selection, expiration settings, activation toggle
- Full i18n translations

**GitHub Actions**
- `sync-feedback.yml` workflow triggered on issue close
- Extracts Feedback IDs from issue body and calls resolve endpoint
- Handles duplicate issues and error cases

## Test plan
- [ ] Create an API key in admin panel
- [ ] Copy the key (verify it's only shown once)
- [ ] Test API key authentication: `curl -H "X-API-Key: <key>" /api/v1/feedback/admin/<id>/resolve`
- [ ] Verify inactive/expired keys are rejected
- [ ] Verify non-admin users cannot access API key endpoints
- [ ] Run `uv run pytest tests/apikeys/` - all 30 tests pass

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)