### PR TITLE
feat(ai): add user-supplied custom prompts for AI classification

### DIFF
--- a/backend/src/ai/service.py
+++ b/backend/src/ai/service.py
@@ -152,7 +152,10 @@ class AIClassificationService:
         return self._template_manager
 
     async def classify_image(
-        self, image_data: bytes, mime_type: str = "image/jpeg"
+        self,
+        image_data: bytes,
+        mime_type: str = "image/jpeg",
+        custom_prompt: str | None = None,
     ) -> ClassificationResult:
         """
         Classify an image using GPT-4 Vision.
@@ -160,6 +163,7 @@ class AIClassificationService:
         Args:
             image_data: Raw image bytes
             mime_type: MIME type of the image
+            custom_prompt: Optional user-supplied prompt to augment the AI request
 
         Returns:
             ClassificationResult with identified item details
@@ -171,6 +175,12 @@ class AIClassificationService:
         user_prompt = self._template_manager.get_user_prompt(
             TEMPLATE_ITEM_CLASSIFICATION
         )
+
+        # Append custom prompt if provided
+        if custom_prompt:
+            user_prompt = (
+                f"{user_prompt}\n\nAdditional context from the user:\n{custom_prompt}"
+            )
 
         # Encode image to base64
         base64_image = base64.b64encode(image_data).decode("utf-8")

--- a/backend/src/images/router.py
+++ b/backend/src/images/router.py
@@ -214,6 +214,7 @@ async def classify_image(
         classification = await ai_service.classify_image(
             image_data,
             mime_type=image.mime_type or "image/jpeg",
+            custom_prompt=data.custom_prompt,
         )
 
         # Deduct credit after successful classification

--- a/backend/src/images/schemas.py
+++ b/backend/src/images/schemas.py
@@ -60,6 +60,7 @@ class ClassificationRequest(BaseModel):
     """Schema for image classification request."""
 
     image_id: UUID
+    custom_prompt: str | None = None
 
 
 class ClassificationResult(BaseModel):

--- a/backend/tests/ai/test_ai_service.py
+++ b/backend/tests/ai/test_ai_service.py
@@ -1,0 +1,215 @@
+"""Tests for AI classification service."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.ai.service import AIClassificationService
+
+
+class TestAIClassificationService:
+    """Tests for the AIClassificationService class."""
+
+    @pytest.fixture
+    def mock_settings(self):
+        """Create mock settings."""
+        settings = MagicMock()
+        settings.openai_api_key = "test-api-key"
+        settings.openai_model = "gpt-4-vision-preview"
+        settings.ai_templates_dir = None
+        return settings
+
+    @pytest.fixture
+    def mock_template_manager(self):
+        """Create mock template manager."""
+        manager = MagicMock()
+        manager.get_system_prompt.return_value = (
+            "You are an expert inventory assistant."
+        )
+        manager.get_user_prompt.return_value = (
+            "Analyze this image and return JSON with identified_name."
+        )
+        return manager
+
+    @pytest.fixture
+    def service(self, mock_settings, mock_template_manager):
+        """Create AI service with mocked dependencies."""
+        with patch("src.ai.service.AsyncOpenAI"):
+            service = AIClassificationService(
+                settings=mock_settings, template_manager=mock_template_manager
+            )
+            return service
+
+    async def test_classify_image_without_custom_prompt(
+        self, service, mock_template_manager
+    ):
+        """Test classification without custom prompt uses default prompts."""
+        # Mock the OpenAI response
+        mock_response = MagicMock()
+        mock_response.choices = [
+            MagicMock(
+                message=MagicMock(
+                    content='{"identified_name": "Test Item", "confidence": 0.95, '
+                    '"category_path": "Test > Category", "description": "A test item", '
+                    '"specifications": {}}'
+                )
+            )
+        ]
+        service.client.chat.completions.create = AsyncMock(return_value=mock_response)
+
+        # Call classify_image without custom_prompt
+        result = await service.classify_image(
+            b"fake_image_data", mime_type="image/jpeg"
+        )
+
+        # Verify result
+        assert result.identified_name == "Test Item"
+        assert result.confidence == 0.95
+
+        # Verify that template manager was called
+        mock_template_manager.get_system_prompt.assert_called_once()
+        mock_template_manager.get_user_prompt.assert_called_once()
+
+        # Verify the user prompt was NOT modified
+        call_args = service.client.chat.completions.create.call_args
+        messages = call_args.kwargs["messages"]
+        user_message = messages[1]
+        user_content = user_message["content"][0]["text"]
+        assert "Additional context from the user" not in user_content
+
+    async def test_classify_image_with_custom_prompt(
+        self, service, mock_template_manager
+    ):
+        """Test classification with custom prompt appends user context."""
+        # Mock the OpenAI response
+        mock_response = MagicMock()
+        mock_response.choices = [
+            MagicMock(
+                message=MagicMock(
+                    content='{"identified_name": "Bin A1", "confidence": 0.92, '
+                    '"category_path": "Storage > Bins", "description": "A storage bin", '
+                    '"specifications": {"location": "A1"}}'
+                )
+            )
+        ]
+        service.client.chat.completions.create = AsyncMock(return_value=mock_response)
+
+        custom_prompt = "Label bins using the format Row-Column (e.g., A1, B3)"
+
+        # Call classify_image with custom_prompt
+        result = await service.classify_image(
+            b"fake_image_data", mime_type="image/jpeg", custom_prompt=custom_prompt
+        )
+
+        # Verify result
+        assert result.identified_name == "Bin A1"
+
+        # Verify the user prompt was modified to include custom context
+        call_args = service.client.chat.completions.create.call_args
+        messages = call_args.kwargs["messages"]
+        user_message = messages[1]
+        user_content = user_message["content"][0]["text"]
+        assert "Additional context from the user" in user_content
+        assert custom_prompt in user_content
+
+    async def test_classify_image_with_empty_custom_prompt(
+        self, service, mock_template_manager
+    ):
+        """Test classification with empty custom prompt behaves like no custom prompt."""
+        # Mock the OpenAI response
+        mock_response = MagicMock()
+        mock_response.choices = [
+            MagicMock(
+                message=MagicMock(
+                    content='{"identified_name": "Test Item", "confidence": 0.9, '
+                    '"category_path": "Test", "description": "Item", "specifications": {}}'
+                )
+            )
+        ]
+        service.client.chat.completions.create = AsyncMock(return_value=mock_response)
+
+        # Call with empty string
+        await service.classify_image(
+            b"fake_image_data", mime_type="image/jpeg", custom_prompt=""
+        )
+
+        # Verify the user prompt was NOT modified
+        call_args = service.client.chat.completions.create.call_args
+        messages = call_args.kwargs["messages"]
+        user_message = messages[1]
+        user_content = user_message["content"][0]["text"]
+        assert "Additional context from the user" not in user_content
+
+    async def test_classify_image_with_none_custom_prompt(
+        self, service, mock_template_manager
+    ):
+        """Test classification with None custom prompt behaves like no custom prompt."""
+        # Mock the OpenAI response
+        mock_response = MagicMock()
+        mock_response.choices = [
+            MagicMock(
+                message=MagicMock(
+                    content='{"identified_name": "Test Item", "confidence": 0.9, '
+                    '"category_path": "Test", "description": "Item", "specifications": {}}'
+                )
+            )
+        ]
+        service.client.chat.completions.create = AsyncMock(return_value=mock_response)
+
+        # Call with None (explicit)
+        await service.classify_image(
+            b"fake_image_data", mime_type="image/jpeg", custom_prompt=None
+        )
+
+        # Verify the user prompt was NOT modified
+        call_args = service.client.chat.completions.create.call_args
+        messages = call_args.kwargs["messages"]
+        user_message = messages[1]
+        user_content = user_message["content"][0]["text"]
+        assert "Additional context from the user" not in user_content
+
+    async def test_classify_image_custom_prompt_preserved_in_api_call(
+        self, service, mock_template_manager
+    ):
+        """Test that custom prompt is correctly included in the API call."""
+        # Mock the OpenAI response
+        mock_response = MagicMock()
+        mock_response.choices = [
+            MagicMock(
+                message=MagicMock(
+                    content='{"identified_name": "Component", "confidence": 0.85, '
+                    '"category_path": "Electronics", "description": "Electronic component", '
+                    '"specifications": {}}'
+                )
+            )
+        ]
+        service.client.chat.completions.create = AsyncMock(return_value=mock_response)
+
+        custom_prompt = "This is a custom electronic component from my PCB project"
+
+        await service.classify_image(
+            b"fake_image_data", mime_type="image/png", custom_prompt=custom_prompt
+        )
+
+        # Verify the full message structure
+        call_args = service.client.chat.completions.create.call_args
+        messages = call_args.kwargs["messages"]
+
+        # Check system message
+        assert messages[0]["role"] == "system"
+
+        # Check user message structure
+        assert messages[1]["role"] == "user"
+        assert isinstance(messages[1]["content"], list)
+
+        # First content should be text with the combined prompt
+        text_content = messages[1]["content"][0]
+        assert text_content["type"] == "text"
+        assert "Additional context from the user:" in text_content["text"]
+        assert "custom electronic component" in text_content["text"]
+        assert "PCB project" in text_content["text"]
+
+        # Second content should be image
+        image_content = messages[1]["content"][1]
+        assert image_content["type"] == "image_url"
+        assert image_content["image_url"]["url"].startswith("data:image/png;base64,")

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -278,7 +278,12 @@
     "alternativeSuggestions": "Alternative Suggestions",
     "filename": "Filename",
     "classified": "Classified",
-    "createItemFromThis": "Create Item from This"
+    "createItemFromThis": "Create Item from This",
+    "customPrompt": {
+      "title": "Custom AI Instructions",
+      "description": "Provide additional context to help the AI better identify your item. For example, specify naming conventions like 'bin X,Y' or provide specific details about the item.",
+      "placeholder": "e.g., 'This is a bin from a storage rack. Label bins using the format Row-Column (e.g., A1, B3)'"
+    }
   },
   "ai": {},
   "billing": {

--- a/frontend/src/lib/api/api-client.ts
+++ b/frontend/src/lib/api/api-client.ts
@@ -370,10 +370,10 @@ export const imagesApi = {
   upload: (file: File) =>
     uploadFile("/api/v1/images/upload", file) as Promise<ImageUpload>,
 
-  classify: (imageId: string) =>
+  classify: (imageId: string, customPrompt?: string) =>
     apiRequest<ClassificationResponse>("/api/v1/images/classify", {
       method: "POST",
-      body: { image_id: imageId },
+      body: { image_id: imageId, custom_prompt: customPrompt || null },
     }),
 
   get: (id: string) => apiRequest<Image>(`/api/v1/images/${id}`),


### PR DESCRIPTION
## Summary

- Adds ability for users to provide custom instructions when classifying images with AI
- Enables more tailored and accurate AI classification based on user context
- Specific use case: specifying naming conventions like 'bin X,Y' for location codes in storage photos

## Changes

**Backend:**
- Add `custom_prompt` optional field to `ClassificationRequest` schema
- Update `AIClassificationService.classify_image()` to accept and append custom prompts to the user message
- Pass custom prompt from classification endpoint to AI service

**Frontend:**
- Add collapsible "Custom AI Instructions" section to image upload component
- Add textarea for users to enter additional context for the AI
- Add i18n translations for new UI strings
- Section only shows when an image is uploaded but not yet classified

**Tests:**
- Add comprehensive unit tests for custom prompt functionality in AI service
- Tests cover: no prompt, with prompt, empty prompt, None prompt cases

## Screenshots

The UI shows a collapsible panel below the uploaded image where users can optionally provide additional instructions before clicking "Identify Item".

## Test plan

- [ ] Upload an image and classify without custom prompt (should work as before)
- [ ] Upload an image, expand "Custom AI Instructions", enter a prompt like "Label bins using format A1, B2", and classify
- [ ] Verify the AI response incorporates the custom context
- [ ] Run backend tests: `cd backend && uv run pytest tests/ai/`
- [ ] Run frontend build: `cd frontend && pnpm build`

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)