### PR TITLE
fix: use AuthenticatedImage for similar items display

### DIFF
--- a/frontend/src/components/items/similar-items-display.tsx
+++ b/frontend/src/components/items/similar-items-display.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { Package, AlertTriangle, ExternalLink, Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { AuthenticatedImage } from "@/components/ui/authenticated-image";
 import { SimilarItemMatch } from "@/lib/api/api-client";
 import { cn } from "@/lib/utils";
 import { useTranslations } from "next-intl";
@@ -55,10 +56,12 @@ export function SimilarItemsDisplay({
             {/* Image placeholder or actual image */}
             <div className="flex h-16 w-16 shrink-0 items-center justify-center rounded-lg bg-amber-100 dark:bg-amber-900/50">
               {item.primary_image_url ? (
-                <img
-                  src={item.primary_image_url}
+                <AuthenticatedImage
+                  imageId={item.primary_image_url.split("/").at(-2)!}
                   alt={item.name}
+                  thumbnail
                   className="h-full w-full rounded-lg object-cover"
+                  fallback={<Package className="h-8 w-8 text-amber-400" />}
                 />
               ) : (
                 <Package className="h-8 w-8 text-amber-400" />


### PR DESCRIPTION
## Summary
- Fixed broken image links in the similar items display component
- Similar items were using direct `<img>` tags with protected API paths (`/api/v1/images/{id}/file`)
- Now uses `AuthenticatedImage` component which fetches signed URLs before displaying

## Root Cause
The `primary_image_url` field contains a relative API path that requires authentication. Direct `<img>` tags cannot send authentication headers, causing 401 errors and broken image icons.

## Solution
Replace the direct `<img>` tag with the existing `AuthenticatedImage` component, following the same pattern used in `items-panel.tsx` and other components in the codebase.

## Test plan
- [ ] Create an item with an image
- [ ] Create another item with a similar name to trigger duplicate detection
- [ ] Verify the similar item's image displays correctly

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)