### PR TITLE
fix(items): prevent checkout when insufficient stock available

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -639,7 +639,9 @@
     "noUsageYet": "No usage history yet",
     "showingRecentHistory": "Showing 5 of {count} records",
     "checkInDisabled": "No items checked out",
-    "exceedsCheckedOut": "Cannot check in more than {count} items"
+    "exceedsCheckedOut": "Cannot check in more than {count} items",
+    "checkOutDisabled": "No items available for checkout",
+    "exceedsAvailable": "Cannot check out more than {count} available items"
   },
   "locationSuggestion": {
     "title": "AI Location Suggestions",

--- a/frontend/src/app/(dashboard)/items/[id]/page.tsx
+++ b/frontend/src/app/(dashboard)/items/[id]/page.tsx
@@ -460,19 +460,56 @@ export default function ItemDetailPage() {
                 />
               </div>
               <div className="flex gap-2">
-                <Button
-                  variant="outline"
-                  onClick={handleCheckOut}
-                  disabled={
-                    checkOutMutation.isPending || checkInMutation.isPending
-                  }
-                  className="flex-1 gap-2"
-                >
-                  <LogOut className="h-4 w-4" />
-                  {checkOutMutation.isPending
-                    ? tCommon("loading")
-                    : t("checkOut")}
-                </Button>
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span className="flex-1">
+                        <Button
+                          variant="outline"
+                          onClick={handleCheckOut}
+                          disabled={
+                            checkOutMutation.isPending ||
+                            checkInMutation.isPending ||
+                            !item ||
+                            !usageStats ||
+                            item.quantity - usageStats.currently_checked_out <=
+                              0 ||
+                            checkInOutQuantity >
+                              item.quantity - usageStats.currently_checked_out
+                          }
+                          className="w-full gap-2"
+                        >
+                          <LogOut className="h-4 w-4" />
+                          {checkOutMutation.isPending
+                            ? tCommon("loading")
+                            : t("checkOut")}
+                        </Button>
+                      </span>
+                    </TooltipTrigger>
+                    {item &&
+                      usageStats &&
+                      item.quantity - usageStats.currently_checked_out <= 0 && (
+                        <TooltipContent>
+                          <p>{t("checkOutDisabled")}</p>
+                        </TooltipContent>
+                      )}
+                    {item &&
+                      usageStats &&
+                      item.quantity - usageStats.currently_checked_out > 0 &&
+                      checkInOutQuantity >
+                        item.quantity - usageStats.currently_checked_out && (
+                        <TooltipContent>
+                          <p>
+                            {t("exceedsAvailable", {
+                              count:
+                                item.quantity -
+                                usageStats.currently_checked_out,
+                            })}
+                          </p>
+                        </TooltipContent>
+                      )}
+                  </Tooltip>
+                </TooltipProvider>
                 <TooltipProvider>
                   <Tooltip>
                     <TooltipTrigger asChild>


### PR DESCRIPTION
## Summary
- Adds backend validation to prevent checking out more items than available (item.quantity - currently_checked_out)
- Uses row-level locking on checkout to prevent race conditions
- Adds frontend validation to disable checkout button when no items available or requested quantity exceeds available stock
- Adds tooltip messages explaining why checkout is disabled
- Adds comprehensive tests for checkout quantity validation

## Test plan
- [x] Backend tests pass (`uv run pytest`)
- [x] Frontend builds successfully (`pnpm build`)
- [x] Lint and format checks pass

### Manual testing
- [ ] Try to check out an item with quantity=1 twice (second should be blocked)
- [ ] Try to check out more items than available (should show error)
- [ ] Verify checkout button is disabled when no stock available
- [ ] Verify tooltip shows explanation for why button is disabled

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)