### PR TITLE
feat(gridfinity): expand planner with bin size recommendations

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -10,6 +10,7 @@
     "update": "Update",
     "search": "Search",
     "filters": "Filters",
+    "unknownError": "An unknown error occurred",
     "clearAll": "Clear all",
     "viewDetails": "View details",
     "noResults": "No results found",
@@ -691,6 +692,8 @@
     "exportPdf": "Export PDF",
     "printLabels": "Print Labels",
     "positionCode": "Position",
+    "loadError": "Failed to load unit: {error}",
+    "autoLayoutPartialError": "Placed {success} items, but {failed} failed to place",
     "placementDialog": {
       "title": "Select Bin Size",
       "description": "Choose the bin size for \"{item}\"",


### PR DESCRIPTION
## Summary

- **Bin size recommendations in sidebar**: Items now display their recommended grid units (e.g., 2×1) based on their dimensions, with tooltips showing the reasoning
- **Placement dialog with size selection**: When dropping an item on the grid, a dialog appears with preset bin sizes (1×1, 1×2, 2×1, 2×2, etc.) and the recommended size highlighted
- **Resize existing placements**: Click the resize button on placed items to adjust their bin size after placement
- **Custom size inputs**: Users can enter custom width/depth values beyond the presets
- **Visual preview**: Shows the selected size in grid units and millimeters

## Test plan

- [ ] Open the gridfinity planner for a storage unit
- [ ] Add items with dimensions set (via item attributes)
- [ ] Verify recommended bin sizes appear in the sidebar next to each item
- [ ] Drag an item onto the grid and verify the placement dialog appears
- [ ] Confirm the recommended size is pre-selected and highlighted
- [ ] Test selecting different preset sizes and custom values
- [ ] Place the item and verify it appears with the correct size
- [ ] Hover over a placed item and click the resize button
- [ ] Verify the edit dialog allows changing the bin size
- [ ] Test the auto-layout feature still works correctly

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)