### PR TITLE
feat(frontend): improve storage planner wizard UX

### DIFF
--- a/frontend/e2e/storage-planner-wizard.spec.ts
+++ b/frontend/e2e/storage-planner-wizard.spec.ts
@@ -1,23 +1,23 @@
 import { test, expect } from "@playwright/test";
 import { setupApiMocks, authenticateUser } from "./mocks/api-handlers";
 
-test.describe("Storage Planner Wizard", () => {
+test.describe("Storage Planner Create", () => {
   test.beforeEach(async ({ page }) => {
     await authenticateUser(page);
     await setupApiMocks(page);
   });
 
-  test("opens wizard from Storage Planner page", async ({ page }) => {
+  test("opens create dialog from Storage Planner page", async ({ page }) => {
     await page.goto("/gridfinity");
 
-    // Verify the wizard button is visible
-    const wizardButton = page.getByTestId("open-wizard-button");
-    await expect(wizardButton).toBeVisible();
+    // Verify the create button is visible
+    const createButton = page.getByTestId("open-wizard-button");
+    await expect(createButton).toBeVisible();
 
-    // Click the wizard button
-    await wizardButton.click();
+    // Click the create button
+    await createButton.click();
 
-    // Verify wizard dialog is open
+    // Verify create dialog is open
     await expect(page.getByTestId("storage-planner-wizard")).toBeVisible();
   });
 
@@ -162,58 +162,36 @@ test.describe("Storage Planner Wizard", () => {
     await page.waitForURL(/\/gridfinity\/gf-unit-\d+/);
   });
 
-  test("shows coming soon message for multiboard type", async ({ page }) => {
+  test("disables multiboard type selection (coming soon)", async ({ page }) => {
     await page.goto("/gridfinity");
     await page.getByTestId("open-wizard-button").click();
 
-    // Select Multiboard type
+    // Multiboard type should be visible but disabled
     const multiboardButton = page.getByTestId("storage-type-multiboard");
     await expect(multiboardButton).toBeVisible();
+    await expect(multiboardButton).toBeDisabled();
 
     // Should show coming soon badge
     await expect(multiboardButton.getByText("Coming Soon")).toBeVisible();
 
-    await multiboardButton.click();
-    await page.getByTestId("wizard-next-button").click();
-
-    // Configuration step should show coming soon message
-    await expect(page.getByTestId("step-configuration")).toBeVisible();
-    await expect(
-      page.getByText("Multiboard Support Coming Soon")
-    ).toBeVisible();
-
-    // Can still navigate to review
-    await page.getByTestId("wizard-next-button").click();
-    await expect(page.getByTestId("step-review")).toBeVisible();
-
-    // But create button should be disabled for coming soon types
-    await expect(page.getByTestId("wizard-create-button")).toBeDisabled();
+    // Should have reduced opacity
+    await expect(multiboardButton).toHaveClass(/opacity-60/);
   });
 
-  test("shows coming soon message for tote-rack type", async ({ page }) => {
+  test("disables tote-rack type selection (coming soon)", async ({ page }) => {
     await page.goto("/gridfinity");
     await page.getByTestId("open-wizard-button").click();
 
-    // Select Tote Rack type
-    const toteRackButton = page.getByTestId("storage-type-tote-rack");
+    // Tote Rack type should be visible but disabled
+    const toteRackButton = page.getByTestId("storage-type-toteRack");
     await expect(toteRackButton).toBeVisible();
+    await expect(toteRackButton).toBeDisabled();
 
     // Should show coming soon badge
     await expect(toteRackButton.getByText("Coming Soon")).toBeVisible();
 
-    await toteRackButton.click();
-    await page.getByTestId("wizard-next-button").click();
-
-    // Configuration step should show coming soon message
-    await expect(page.getByTestId("step-configuration")).toBeVisible();
-    await expect(page.getByText("Tote Rack Support Coming Soon")).toBeVisible();
-
-    // Can still navigate to review
-    await page.getByTestId("wizard-next-button").click();
-    await expect(page.getByTestId("step-review")).toBeVisible();
-
-    // But create button should be disabled for coming soon types
-    await expect(page.getByTestId("wizard-create-button")).toBeDisabled();
+    // Should have reduced opacity
+    await expect(toteRackButton).toHaveClass(/opacity-60/);
   });
 
   test("cancels wizard from first step", async ({ page }) => {
@@ -374,10 +352,15 @@ test.describe("Storage Planner Wizard", () => {
     // All three types should be visible
     await expect(page.getByTestId("storage-type-gridfinity")).toBeVisible();
     await expect(page.getByTestId("storage-type-multiboard")).toBeVisible();
-    await expect(page.getByTestId("storage-type-tote-rack")).toBeVisible();
+    await expect(page.getByTestId("storage-type-toteRack")).toBeVisible();
 
-    // Only Gridfinity should not have coming soon badge
+    // Only Gridfinity should be enabled (not have coming soon badge)
     const gridfinityButton = page.getByTestId("storage-type-gridfinity");
     await expect(gridfinityButton.getByText("Coming Soon")).not.toBeVisible();
+    await expect(gridfinityButton).toBeEnabled();
+
+    // Multiboard and Tote Rack should be disabled
+    await expect(page.getByTestId("storage-type-multiboard")).toBeDisabled();
+    await expect(page.getByTestId("storage-type-toteRack")).toBeDisabled();
   });
 });

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -739,9 +739,9 @@
     "description": "Description"
   },
   "storagePlanner": {
-    "wizard": "Wizard",
-    "wizardTitle": "Storage Planner Wizard",
-    "wizardDescription": "Create a new storage planning system with guided setup",
+    "create": "Create",
+    "createTitle": "Create Storage System",
+    "createDescription": "Set up a new storage planning system to organize your inventory items with precision placement and visual planning tools.",
     "step": "Step {current} of {total}",
     "steps": {
       "type-selection": "Select Storage Type",
@@ -750,33 +750,38 @@
     },
     "back": "Back",
     "next": "Next",
-    "create": "Create",
     "comingSoon": "Coming Soon",
     "selectType": {
       "title": "Choose Your Storage System",
-      "description": "Select the type of storage system you want to plan"
+      "description": "Different storage systems work best for different use cases. Select the type that matches your physical storage setup.",
+      "helpText": "Not sure which to choose? Gridfinity is great for drawers and toolboxes, while pegboards work well for wall-mounted tool organization."
     },
     "configuration": {
       "title": "Configure Your Storage",
-      "description": "Set up the dimensions and details for your {type}"
+      "description": "Set up the dimensions and details for your {type}. Measure your physical container to ensure accurate grid planning."
     },
     "review": {
       "title": "Review Your Configuration",
-      "description": "Confirm your storage setup before creating",
+      "description": "Confirm your storage setup before creating. You can edit these settings later if needed.",
       "dimensions": "Dimensions",
       "comingSoon": "Feature Coming Soon",
       "comingSoonDescription": "This storage type is not yet available. Please select Gridfinity to proceed."
     },
     "gridfinity": {
       "title": "Gridfinity",
-      "description": "Modular 3D-printed storage system with standardized 42mm grid units",
+      "description": "The popular open-source modular storage system. Perfect for organizing small parts, tools, and components in drawers and containers.",
+      "longDescription": "Gridfinity uses a standardized 42mm grid system that allows you to mix and match bins of different sizes. Plan exactly where each item goes, then 3D print bins to fit.",
       "feature1": "Standard 42mm grid spacing",
       "feature2": "Drag-and-drop item placement",
-      "feature3": "Auto-layout algorithm"
+      "feature3": "AI-powered bin size recommendations",
+      "useCase1": "Workshop tool drawers",
+      "useCase2": "Electronics component storage",
+      "useCase3": "Craft supply organization"
     },
     "multiboard": {
       "title": "Multiboard / Pegboard / Honeycomb",
-      "description": "Wall-mounted storage with hooks and accessories for tools and supplies",
+      "description": "Wall-mounted modular storage with hooks and accessories. Ideal for frequently-used tools and supplies.",
+      "longDescription": "Plan your wall storage layout before drilling a single hole. Visualize hook placements and ensure you have room for all your tools.",
       "feature1": "Multiple board type support",
       "feature2": "Hook and accessory planning",
       "feature3": "Wall space optimization",
@@ -785,7 +790,8 @@
     },
     "toteRack": {
       "title": "Storage Tote Rack",
-      "description": "Shelving system for organizing storage bins and totes",
+      "description": "Organize bins and totes on shelving units. Track what's in each bin with a visual map of your storage rack.",
+      "longDescription": "Create a digital map of your shelving system. Know exactly which bin contains what, and generate labels to mark each position.",
       "feature1": "Row and column planning",
       "feature2": "Bin size tracking",
       "feature3": "Label generation",

--- a/frontend/src/components/storage-planner/storage-planner-wizard.tsx
+++ b/frontend/src/components/storage-planner/storage-planner-wizard.tsx
@@ -28,12 +28,13 @@ import {
 import { cn } from "@/lib/utils";
 
 // Storage type definitions
-export type StorageType = "gridfinity" | "multiboard" | "tote-rack";
+export type StorageType = "gridfinity" | "multiboard" | "toteRack";
 
 interface StorageTypeOption {
   id: StorageType;
   icon: React.ReactNode;
   features: string[];
+  isComingSoon?: boolean;
 }
 
 // Wizard step definitions
@@ -111,15 +112,17 @@ export function StoragePlannerWizard({
         t("multiboard.feature2"),
         t("multiboard.feature3"),
       ],
+      isComingSoon: true,
     },
     {
-      id: "tote-rack",
+      id: "toteRack",
       icon: <Package className="h-8 w-8" />,
       features: [
         t("toteRack.feature1"),
         t("toteRack.feature2"),
         t("toteRack.feature3"),
       ],
+      isComingSoon: true,
     },
   ];
 
@@ -162,9 +165,9 @@ export function StoragePlannerWizard({
         if (selectedType === "gridfinity") {
           return gridfinityData.name.trim() !== "";
         }
-        // Multiboard and tote-rack are coming soon, so they always pass
+        // Multiboard and toteRack are coming soon, so they always pass
         // configuration step (we show coming soon message instead)
-        if (selectedType === "multiboard" || selectedType === "tote-rack") {
+        if (selectedType === "multiboard" || selectedType === "toteRack") {
           return true;
         }
         return false;
@@ -179,7 +182,7 @@ export function StoragePlannerWizard({
     if (selectedType === "gridfinity") {
       createGridfinityMutation.mutate(gridfinityData);
     }
-    // For now, multiboard and tote-rack are coming soon
+    // For now, multiboard and toteRack are coming soon
     // TODO: Implement when backend support is added
   };
 
@@ -222,10 +225,13 @@ export function StoragePlannerWizard({
         {/* Step 1: Type Selection */}
         {currentStep === "type-selection" && (
           <div className="space-y-6" data-testid="step-type-selection">
-            <div>
+            <div className="space-y-2">
               <h2 className="text-lg font-semibold">{t("selectType.title")}</h2>
               <p className="text-muted-foreground">
                 {t("selectType.description")}
+              </p>
+              <p className="text-sm text-muted-foreground/80">
+                {t("selectType.helpText")}
               </p>
             </div>
 
@@ -234,13 +240,16 @@ export function StoragePlannerWizard({
                 <button
                   key={type.id}
                   type="button"
-                  onClick={() => setSelectedType(type.id)}
+                  onClick={() => !type.isComingSoon && setSelectedType(type.id)}
+                  disabled={type.isComingSoon}
                   data-testid={`storage-type-${type.id}`}
                   className={cn(
                     "group relative flex flex-col rounded-xl border-2 p-6 text-left transition-all",
-                    selectedType === type.id
-                      ? "border-primary bg-primary/5"
-                      : "border-border hover:border-primary/50"
+                    type.isComingSoon
+                      ? "cursor-not-allowed border-border opacity-60"
+                      : selectedType === type.id
+                        ? "border-primary bg-primary/5"
+                        : "border-border hover:border-primary/50"
                   )}
                 >
                   {/* Selected indicator */}
@@ -287,8 +296,8 @@ export function StoragePlannerWizard({
                     ))}
                   </ul>
 
-                  {/* Coming soon badge for non-gridfinity */}
-                  {type.id !== "gridfinity" && (
+                  {/* Coming soon badge */}
+                  {type.isComingSoon && (
                     <div className="mt-4 inline-flex items-center gap-1 rounded-full bg-amber-100 px-2 py-1 text-xs font-medium text-amber-800 dark:bg-amber-900/30 dark:text-amber-400">
                       <Info className="h-3 w-3" />
                       {t("comingSoon")}
@@ -482,7 +491,7 @@ export function StoragePlannerWizard({
             )}
 
             {/* Tote Rack Configuration (Coming Soon) */}
-            {selectedType === "tote-rack" && (
+            {selectedType === "toteRack" && (
               <div className="flex flex-col items-center justify-center py-12 text-center">
                 <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-amber-100 dark:bg-amber-900/30">
                   <Info className="h-8 w-8 text-amber-600 dark:text-amber-400" />
@@ -553,8 +562,7 @@ export function StoragePlannerWizard({
               </div>
             )}
 
-            {(selectedType === "multiboard" ||
-              selectedType === "tote-rack") && (
+            {(selectedType === "multiboard" || selectedType === "toteRack") && (
               <div className="flex flex-col items-center justify-center py-12 text-center">
                 <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-amber-100 dark:bg-amber-900/30">
                   <Info className="h-8 w-8 text-amber-600 dark:text-amber-400" />
@@ -593,7 +601,7 @@ export function StoragePlannerWizard({
                 !canProceed() ||
                 isCreating ||
                 selectedType === "multiboard" ||
-                selectedType === "tote-rack"
+                selectedType === "toteRack"
               }
               data-testid="wizard-create-button"
             >


### PR DESCRIPTION
## Summary
- Remove separate quick create button/dialog in favor of unified wizard-only flow for creating storage units
- Rename "Wizard" to "Create" throughout the UI for clearer intent
- Fix translation key mismatch (`tote-rack` -> `toteRack`) that caused missing translations
- Disable coming soon storage types (multiboard, toteRack) from being selected in the wizard
- Add detailed explanations and help text to guide users through the wizard steps

## Test plan
- [ ] Open Storage Planner page and verify only "Create" button exists (no separate quick create)
- [ ] Click "Create" and verify wizard opens with improved descriptions
- [ ] Verify multiboard and tote rack options show "Coming Soon" badge and are disabled
- [ ] Verify Gridfinity option can be selected and wizard completes successfully
- [ ] Run e2e tests: `pnpm test:e2e`

🤖 Generated with [Claude Code](https://claude.com/claude-code)