### PR TITLE
feat(frontend): improve sidebar UX for viewer context clarity

### DIFF
--- a/frontend/src/components/layout/inventory-switcher.tsx
+++ b/frontend/src/components/layout/inventory-switcher.tsx
@@ -3,6 +3,7 @@
 import { useTranslations } from "next-intl";
 import { Check, ChevronDown, Users } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
+import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -61,14 +62,24 @@ export function InventorySwitcher() {
       <DropdownMenuTrigger asChild>
         <Button
           variant="outline"
-          className="w-full justify-between gap-2 text-left"
+          className={cn(
+            "h-auto w-full justify-between gap-2 px-3 py-2.5 text-left",
+            isViewingSharedInventory
+              ? "border-blue-200 bg-blue-50/50 hover:bg-blue-50 dark:border-blue-800 dark:bg-blue-950/30 dark:hover:bg-blue-950/50"
+              : "hover:bg-muted"
+          )}
           data-testid="inventory-switcher"
         >
           <div className="flex items-center gap-2 truncate">
-            {isViewingSharedInventory && (
-              <Users className="h-4 w-4 shrink-0 text-muted-foreground" />
-            )}
-            <span className="truncate">{displayName}</span>
+            <Users
+              className={cn(
+                "h-4 w-4 shrink-0",
+                isViewingSharedInventory
+                  ? "text-blue-600 dark:text-blue-400"
+                  : "text-muted-foreground"
+              )}
+            />
+            <span className="truncate font-medium">{displayName}</span>
           </div>
           <ChevronDown className="h-4 w-4 shrink-0 opacity-50" />
         </Button>

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -28,6 +28,16 @@ import {
   InventoryBanner,
 } from "@/components/layout/inventory-switcher";
 
+interface NavSection {
+  label: string;
+  items: {
+    title: string;
+    href: string;
+    icon: React.ComponentType<{ className?: string }>;
+  }[];
+  usesOwnData?: boolean;
+}
+
 interface SidebarProps {
   open?: boolean;
   onClose?: () => void;
@@ -39,7 +49,7 @@ export function Sidebar({ open, onClose }: SidebarProps) {
   const { canEdit, isViewingSharedInventory } = useInventory();
   const t = useTranslations();
 
-  const navSections = [
+  const navSections: NavSection[] = [
     {
       label: t("nav.overview"),
       items: [
@@ -59,11 +69,6 @@ export function Sidebar({ open, onClose }: SidebarProps) {
           icon: Package,
         },
         {
-          title: t("sidebar.checkedOutItems"),
-          href: "/checked-out",
-          icon: ArrowRightFromLine,
-        },
-        {
           title: t("sidebar.categories"),
           href: "/categories",
           icon: FolderOpen,
@@ -74,6 +79,11 @@ export function Sidebar({ open, onClose }: SidebarProps) {
           icon: MapPin,
         },
         {
+          title: t("sidebar.checkedOutItems"),
+          href: "/checked-out",
+          icon: ArrowRightFromLine,
+        },
+        {
           title: t("sidebar.storagePlanner"),
           href: "/gridfinity",
           icon: Grid3X3,
@@ -82,6 +92,7 @@ export function Sidebar({ open, onClose }: SidebarProps) {
     },
     {
       label: t("nav.aiTools"),
+      usesOwnData: true,
       items: [
         {
           title: t("sidebar.aiAssistant"),
@@ -102,16 +113,17 @@ export function Sidebar({ open, onClose }: SidebarProps) {
     },
     {
       label: t("nav.account"),
+      usesOwnData: true,
       items: [
-        {
-          title: t("sidebar.billing"),
-          href: "/settings/billing",
-          icon: CreditCard,
-        },
         {
           title: t("sidebar.settings"),
           href: "/settings",
           icon: Settings,
+        },
+        {
+          title: t("sidebar.billing"),
+          href: "/settings/billing",
+          icon: CreditCard,
         },
         {
           title: t("sidebar.feedback"),
@@ -122,7 +134,7 @@ export function Sidebar({ open, onClose }: SidebarProps) {
     },
   ];
 
-  const adminSection = {
+  const adminSection: NavSection = {
     label: t("nav.admin"),
     items: [
       {
@@ -179,53 +191,70 @@ export function Sidebar({ open, onClose }: SidebarProps) {
         </div>
 
         {/* Inventory Switcher */}
-        <div className="space-y-2 px-3 py-4">
+        <div className="space-y-3 px-3 py-4">
           <InventorySwitcher />
           {isViewingSharedInventory && <InventoryBanner />}
-          {/* Quick Action - only show if user can edit */}
-          {canEdit && (
+        </div>
+
+        {/* Quick Action - only show if user can edit */}
+        {canEdit && (
+          <div className="border-b px-3 pb-4">
             <Link href="/items/new" onClick={onClose}>
               <Button size="sm" className="w-full gap-2">
                 <Plus className="h-4 w-4" />
                 {t("sidebar.newItem")}
               </Button>
             </Link>
-          )}
-        </div>
+          </div>
+        )}
 
         {/* Navigation */}
         <div className="flex-1 overflow-auto px-3 pb-4">
           <nav className="space-y-6">
-            {allSections.map((section) => (
-              <div key={section.label}>
-                <h3 className="mb-2 px-3 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
-                  {section.label}
-                </h3>
-                <div className="space-y-0.5">
-                  {section.items.map((item) => {
-                    const isActive = isItemActive(item.href);
+            {allSections.map((section) => {
+              const isOwnDataSection =
+                isViewingSharedInventory && section.usesOwnData;
 
-                    return (
-                      <Link
-                        key={item.href}
-                        href={item.href}
-                        onClick={onClose}
-                        data-testid={`sidebar-link-${item.href.replace(/\//g, "-").replace(/^-/, "")}`}
-                        className={cn(
-                          "group flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors",
-                          isActive
-                            ? "bg-primary text-primary-foreground"
-                            : "text-muted-foreground hover:bg-muted hover:text-foreground"
-                        )}
-                      >
-                        <item.icon className="h-4 w-4" />
-                        {item.title}
-                      </Link>
-                    );
-                  })}
+              return (
+                <div key={section.label}>
+                  <h3
+                    className={cn(
+                      "mb-2 px-3 text-[11px] font-medium uppercase tracking-wider",
+                      isOwnDataSection
+                        ? "text-blue-600 dark:text-blue-400"
+                        : "text-muted-foreground"
+                    )}
+                  >
+                    {section.label}
+                  </h3>
+                  <div className="space-y-0.5">
+                    {section.items.map((item) => {
+                      const isActive = isItemActive(item.href);
+
+                      return (
+                        <Link
+                          key={item.href}
+                          href={item.href}
+                          onClick={onClose}
+                          data-testid={`sidebar-link-${item.href.replace(/\//g, "-").replace(/^-/, "")}`}
+                          className={cn(
+                            "group flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors",
+                            isActive
+                              ? "bg-primary text-primary-foreground"
+                              : isOwnDataSection
+                                ? "text-blue-600 hover:bg-blue-50 hover:text-blue-700 dark:text-blue-400 dark:hover:bg-blue-950 dark:hover:text-blue-300"
+                                : "text-muted-foreground hover:bg-muted hover:text-foreground"
+                          )}
+                        >
+                          <item.icon className="h-4 w-4" />
+                          {item.title}
+                        </Link>
+                      );
+                    })}
+                  </div>
                 </div>
-              </div>
-            ))}
+              );
+            })}
           </nav>
         </div>
 


### PR DESCRIPTION
## Summary
- Add visual distinction for sections using user's own data when viewing shared inventory (AI Tools and Account sections turn blue)
- Make inventory switcher more prominent with larger size and blue styling when viewing shared inventory
- Add visual separation between inventory switcher and New Item button
- Reorder sidebar links by importance for better usability

## Changes

### Visual Context Indicators
When viewing another user's shared inventory, the "AI Tools" and "Account" sections now appear in blue to indicate these features use YOUR data (not the viewed inventory):
- AI Assistant uses your own inventory and credits
- Account settings are always your own

### Inventory Switcher Improvements
- Larger, more prominent button
- Always shows Users icon
- Blue-tinted styling when viewing shared inventory
- Separated from New Item button with a border

### Link Ordering
Reordered by importance:
- **Inventory**: Items → Categories → Locations → Checked Out → Storage Planner
- **Account**: Settings → Billing → Feedback

## Test plan
- [ ] Verify sidebar displays correctly when viewing own inventory
- [ ] Verify blue styling appears on AI Tools and Account sections when viewing shared inventory
- [ ] Verify inventory switcher is more visible and has proper styling
- [ ] Verify link ordering matches the new arrangement
- [ ] Test in both light and dark modes

🤖 Generated with [Claude Code](https://claude.ai/code)