### PR TITLE
feat(e2e): make backend API URL configurable via env var

### DIFF
--- a/frontend/e2e/items.spec.ts
+++ b/frontend/e2e/items.spec.ts
@@ -162,11 +162,13 @@ test.describe("Items", () => {
             .url()
             .match(/\/images\/([^/]+)\/signed-url/);
           signedUrlCalls.push(match?.[1] || "");
+          const apiUrl =
+            process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
           await route.fulfill({
             status: 200,
             contentType: "application/json",
             body: JSON.stringify({
-              url: `http://localhost:8000/uploads/mock.jpg?token=mock`,
+              url: `${apiUrl}/uploads/mock.jpg?token=mock`,
             }),
           });
         }

--- a/frontend/e2e/mocks/api-handlers.ts
+++ b/frontend/e2e/mocks/api-handlers.ts
@@ -502,11 +502,12 @@ export async function setupApiMocks(page: Page, options: MockOptions = {}) {
   });
 
   await page.route(/\/api\/v1\/images\/[^/]+\/signed-url$/, async (route) => {
+    const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
     await route.fulfill({
       status: 200,
       contentType: "application/json",
       body: JSON.stringify({
-        url: "http://localhost:8000/uploads/mock-signed-url.jpg?token=mock-token",
+        url: `${apiUrl}/uploads/mock-signed-url.jpg?token=mock-token`,
       }),
     });
   });


### PR DESCRIPTION
## Summary
- Use `NEXT_PUBLIC_API_URL` environment variable in Playwright e2e tests instead of hardcoded `localhost:8000`
- Allows running e2e tests against different backend ports/hosts
- Falls back to `http://localhost:8000` when the variable is not set

## Test plan
- [ ] Run `pnpm test:e2e` with default settings (should work as before)
- [ ] Run `NEXT_PUBLIC_API_URL=http://localhost:9000 pnpm test:e2e` to verify custom port is used

🤖 Generated with [Claude Code](https://claude.com/claude-code)