### PR TITLE
fix(gridfinity): use functional state updates for bin size dimensions

### DIFF
--- a/frontend/src/app/(dashboard)/gridfinity/[id]/page.tsx
+++ b/frontend/src/app/(dashboard)/gridfinity/[id]/page.tsx
@@ -650,11 +650,15 @@ export default function GridfinityEditorPage() {
                           isRecommended && !isSelected && "border-primary"
                         )}
                         onClick={() =>
-                          setPendingPlacement({
-                            ...pendingPlacement,
-                            widthUnits: preset.width,
-                            depthUnits: preset.depth,
-                          })
+                          setPendingPlacement((prev) =>
+                            prev
+                              ? {
+                                  ...prev,
+                                  widthUnits: preset.width,
+                                  depthUnits: preset.depth,
+                                }
+                              : prev
+                          )
                         }
                       >
                         {preset.label}
@@ -682,10 +686,17 @@ export default function GridfinityEditorPage() {
                       const value = parseInt(e.target.value) || 1;
                       const maxWidth =
                         (unit?.grid_columns || 1) - pendingPlacement.gridX;
-                      setPendingPlacement({
-                        ...pendingPlacement,
-                        widthUnits: Math.max(1, Math.min(value, maxWidth)),
-                      });
+                      setPendingPlacement((prev) =>
+                        prev
+                          ? {
+                              ...prev,
+                              widthUnits: Math.max(
+                                1,
+                                Math.min(value, maxWidth)
+                              ),
+                            }
+                          : prev
+                      );
                     }}
                   />
                 </div>
@@ -701,10 +712,17 @@ export default function GridfinityEditorPage() {
                       const value = parseInt(e.target.value) || 1;
                       const maxDepth =
                         (unit?.grid_rows || 1) - pendingPlacement.gridY;
-                      setPendingPlacement({
-                        ...pendingPlacement,
-                        depthUnits: Math.max(1, Math.min(value, maxDepth)),
-                      });
+                      setPendingPlacement((prev) =>
+                        prev
+                          ? {
+                              ...prev,
+                              depthUnits: Math.max(
+                                1,
+                                Math.min(value, maxDepth)
+                              ),
+                            }
+                          : prev
+                      );
                     }}
                   />
                 </div>
@@ -776,11 +794,15 @@ export default function GridfinityEditorPage() {
                         variant={isSelected ? "default" : "outline"}
                         size="sm"
                         onClick={() =>
-                          setEditingPlacement({
-                            ...editingPlacement,
-                            widthUnits: preset.width,
-                            depthUnits: preset.depth,
-                          })
+                          setEditingPlacement((prev) =>
+                            prev
+                              ? {
+                                  ...prev,
+                                  widthUnits: preset.width,
+                                  depthUnits: preset.depth,
+                                }
+                              : prev
+                          )
                         }
                       >
                         {preset.label}
@@ -807,10 +829,17 @@ export default function GridfinityEditorPage() {
                       const maxWidth =
                         (unit?.grid_columns || 1) -
                         editingPlacement.placement.grid_x;
-                      setEditingPlacement({
-                        ...editingPlacement,
-                        widthUnits: Math.max(1, Math.min(value, maxWidth)),
-                      });
+                      setEditingPlacement((prev) =>
+                        prev
+                          ? {
+                              ...prev,
+                              widthUnits: Math.max(
+                                1,
+                                Math.min(value, maxWidth)
+                              ),
+                            }
+                          : prev
+                      );
                     }}
                   />
                 </div>
@@ -829,10 +858,17 @@ export default function GridfinityEditorPage() {
                       const maxDepth =
                         (unit?.grid_rows || 1) -
                         editingPlacement.placement.grid_y;
-                      setEditingPlacement({
-                        ...editingPlacement,
-                        depthUnits: Math.max(1, Math.min(value, maxDepth)),
-                      });
+                      setEditingPlacement((prev) =>
+                        prev
+                          ? {
+                              ...prev,
+                              depthUnits: Math.max(
+                                1,
+                                Math.min(value, maxDepth)
+                              ),
+                            }
+                          : prev
+                      );
                     }}
                   />
                 </div>


### PR DESCRIPTION
## Summary
- Fixed stale closure issue in bin size dimension inputs in the Gridfinity Planner placement dialogs
- Changed state setters from object spread pattern (`{...state, field: value}`) to functional update pattern (`(prev) => prev ? {...prev, field: value} : prev`)
- This ensures both width and depth dimensions can be edited independently without values reverting

## Problem
When users tried to change both bin size dimensions (width and depth) in the placement dialogs, one dimension could revert to its previous value. This was caused by stale closures where the `onChange` handlers captured the old state value instead of using the latest state.

## Changes
- Updated 6 state setters in the Gridfinity Editor page:
  - Placement dialog preset button click handler
  - Placement dialog width input onChange handler  
  - Placement dialog depth input onChange handler
  - Edit placement dialog preset button click handler
  - Edit placement dialog width input onChange handler
  - Edit placement dialog depth input onChange handler

## Test plan
- [ ] Create a new Gridfinity unit
- [ ] Place an item on the grid
- [ ] In the placement dialog, manually edit the width dimension
- [ ] Then manually edit the depth dimension
- [ ] Verify both dimensions retain their values
- [ ] Repeat for the edit placement dialog

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)