### PR TITLE
fix(ci): run both vitest and playwright tests in e2e job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,9 +190,13 @@ jobs:
         working-directory: frontend
         run: pnpm exec playwright install --with-deps
 
-      - name: Run Playwright tests
+      - name: Run unit tests
         working-directory: frontend
         run: pnpm test
+
+      - name: Run Playwright tests
+        working-directory: frontend
+        run: pnpm test:e2e
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v6


### PR DESCRIPTION
## Summary
- Fixed the e2e CI job which was incorrectly running `pnpm test` (vitest) instead of Playwright tests
- Added a separate step for unit tests
- Changed the Playwright step to use `pnpm test:e2e`

## Test plan
- [ ] Verify CI runs both vitest unit tests and Playwright e2e tests
- [ ] Check that all 11 Playwright test files are executed

🤖 Generated with [Claude Code](https://claude.com/claude-code)