### PR TITLE
fix(images): remove fixed aspect ratio from gallery main image

### DIFF
--- a/frontend/src/components/items/image-gallery.tsx
+++ b/frontend/src/components/items/image-gallery.tsx
@@ -84,7 +84,7 @@ export function ImageGallery({
 
   if (images.length === 0) {
     return (
-      <div className="flex aspect-video items-center justify-center rounded-xl border bg-muted/50">
+      <div className="flex min-h-[200px] items-center justify-center rounded-xl border bg-muted/50">
         <div className="text-center">
           <Package className="mx-auto h-12 w-12 text-muted-foreground/50" />
           <p className="mt-2 text-sm text-muted-foreground">
@@ -104,7 +104,7 @@ export function ImageGallery({
             <AuthenticatedImage
               imageId={currentImage.id}
               alt={currentImage.original_filename || "Item image"}
-              className="aspect-video w-full object-contain"
+              className="max-h-[70vh] w-full object-contain"
               data-testid="main-gallery-image"
             />
             <div className="absolute inset-0 bg-gradient-to-t from-black/40 via-transparent to-transparent opacity-0 transition-opacity group-hover:opacity-100" />


### PR DESCRIPTION
## Summary
- Replace `aspect-video` constraint with `max-h-[70vh]` on gallery main image to preserve natural aspect ratios
- Update empty state placeholder to use `min-h-[200px]` for consistency

## Problem
When users clicked on an item thumbnail to view details, images with non-16:9 aspect ratios (square, portrait, ultra-wide) were being cropped or letterboxed due to the fixed `aspect-video` class.

## Solution
Changed the main gallery image styling to use `max-h-[70vh] w-full object-contain` which:
- Allows images to display at their natural aspect ratio
- Caps the maximum height at 70% of viewport height to prevent overly tall images
- Maintains full width scaling with `object-contain` to prevent distortion

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)