### PR TITLE
fix(locations): add signed URL for QR code access

### DIFF
--- a/backend/src/auth/service.py
+++ b/backend/src/auth/service.py
@@ -6,6 +6,7 @@ from jose import JWTError, jwt
 from src.config import Settings, get_settings
 
 IMAGE_TOKEN_EXPIRY_MINUTES = 60
+LOCATION_TOKEN_EXPIRY_MINUTES = 60
 
 
 class AuthService:
@@ -55,6 +56,55 @@ class AuthService:
                 return None
             # Verify it's for the correct image
             if payload.get("image_id") != str(image_id):
+                return None
+            user_id_str: str | None = payload.get("sub")
+            if user_id_str is None:
+                return None
+            return UUID(user_id_str)
+        except (JWTError, ValueError):
+            return None
+
+    def create_location_token(self, user_id: UUID, location_id: UUID) -> str:
+        """
+        Create a short-lived token for accessing a specific location's QR code.
+
+        This token is used for browser image loading where Authorization
+        headers cannot be sent (e.g., <img src="...">).
+        """
+        expire = datetime.now(UTC) + timedelta(minutes=LOCATION_TOKEN_EXPIRY_MINUTES)
+
+        to_encode = {
+            "sub": str(user_id),
+            "location_id": str(location_id),
+            "type": "location",
+            "exp": expire,
+            "iat": datetime.now(UTC),
+        }
+
+        return jwt.encode(
+            to_encode,
+            self.settings.jwt_secret,
+            algorithm=self.settings.jwt_algorithm,
+        )
+
+    def verify_location_token(self, token: str, location_id: UUID) -> UUID | None:
+        """
+        Verify a location access token and return the user ID.
+
+        Returns:
+            User ID if token is valid and matches the location_id, None otherwise.
+        """
+        try:
+            payload = jwt.decode(
+                token,
+                self.settings.jwt_secret,
+                algorithms=[self.settings.jwt_algorithm],
+            )
+            # Verify this is a location token
+            if payload.get("type") != "location":
+                return None
+            # Verify it's for the correct location
+            if payload.get("location_id") != str(location_id):
                 return None
             user_id_str: str | None = payload.get("sub")
             if user_id_str is None:

--- a/backend/src/locations/schemas.py
+++ b/backend/src/locations/schemas.py
@@ -174,3 +174,9 @@ class ItemLocationSuggestionResponse(BaseModel):
     success: bool
     suggestions: list[LocationSuggestionItem] = Field(default_factory=list)
     error: str | None = None
+
+
+class LocationQrSignedUrlResponse(BaseModel):
+    """Schema for signed QR code URL response."""
+
+    url: str

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -426,11 +426,13 @@ def mock_stripe_webhook_event(stripe_webhook_payload):
 @pytest.fixture
 async def authenticated_client(
     async_session: AsyncSession,
-    test_settings: Settings,  # noqa: ARG001
-    test_user: User,  # noqa: ARG001
+    test_settings: Settings,
+    test_user: User,
 ) -> AsyncGenerator[AsyncClient, None]:
     """Create an async HTTP client with authenticated user."""
     from src.auth.dependencies import get_current_user_id
+    from src.auth.service import AuthService, get_auth_service
+    from src.config import get_settings
     from src.database import get_session
     from src.main import app
 
@@ -439,6 +441,10 @@ async def authenticated_client(
 
     app.dependency_overrides[get_session] = override_session
     app.dependency_overrides[get_current_user_id] = lambda: test_user.id
+    app.dependency_overrides[get_settings] = lambda: test_settings
+    app.dependency_overrides[get_auth_service] = lambda: AuthService(
+        settings=test_settings
+    )
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
@@ -450,11 +456,13 @@ async def authenticated_client(
 @pytest.fixture
 async def admin_client(
     async_session: AsyncSession,
-    test_settings: Settings,  # noqa: ARG001
-    admin_user: User,  # noqa: ARG001
+    test_settings: Settings,
+    admin_user: User,
 ) -> AsyncGenerator[AsyncClient, None]:
     """Create an async HTTP client with admin user."""
     from src.auth.dependencies import get_current_user_id
+    from src.auth.service import AuthService, get_auth_service
+    from src.config import get_settings
     from src.database import get_session
     from src.main import app
 
@@ -463,6 +471,10 @@ async def admin_client(
 
     app.dependency_overrides[get_session] = override_session
     app.dependency_overrides[get_current_user_id] = lambda: admin_user.id
+    app.dependency_overrides[get_settings] = lambda: test_settings
+    app.dependency_overrides[get_auth_service] = lambda: AuthService(
+        settings=test_settings
+    )
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
@@ -474,9 +486,11 @@ async def admin_client(
 @pytest.fixture
 async def unauthenticated_client(
     async_session: AsyncSession,
-    test_settings: Settings,  # noqa: ARG001
+    test_settings: Settings,
 ) -> AsyncGenerator[AsyncClient, None]:
     """Create an async HTTP client without authentication."""
+    from src.auth.service import AuthService, get_auth_service
+    from src.config import get_settings
     from src.database import get_session
     from src.main import app
 
@@ -484,6 +498,10 @@ async def unauthenticated_client(
         yield async_session
 
     app.dependency_overrides[get_session] = override_session
+    app.dependency_overrides[get_settings] = lambda: test_settings
+    app.dependency_overrides[get_auth_service] = lambda: AuthService(
+        settings=test_settings
+    )
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:

--- a/backend/tests/images/test_signed_urls.py
+++ b/backend/tests/images/test_signed_urls.py
@@ -1,11 +1,15 @@
-"""Tests for image signed URL functionality."""
+"""Tests for image and location signed URL functionality."""
 
 import uuid
 from datetime import UTC, datetime, timedelta
 
 import pytest
 
-from src.auth.service import IMAGE_TOKEN_EXPIRY_MINUTES, AuthService
+from src.auth.service import (
+    IMAGE_TOKEN_EXPIRY_MINUTES,
+    LOCATION_TOKEN_EXPIRY_MINUTES,
+    AuthService,
+)
 from src.config import Settings
 
 
@@ -158,5 +162,155 @@ class TestImageTokenExpiry:
 
         # Verify expiry is approximately IMAGE_TOKEN_EXPIRY_MINUTES from now
         expected_expiry = now + timedelta(minutes=IMAGE_TOKEN_EXPIRY_MINUTES)
+        # Allow 5 seconds tolerance
+        assert abs((exp_time - expected_expiry).total_seconds()) < 5
+
+
+class TestLocationTokenCreation:
+    """Tests for location token creation."""
+
+    def test_create_location_token_returns_string(self, auth_service: AuthService):
+        """Test that create_location_token returns a non-empty string."""
+        user_id = uuid.uuid4()
+        location_id = uuid.uuid4()
+
+        token = auth_service.create_location_token(user_id, location_id)
+
+        assert isinstance(token, str)
+        assert len(token) > 0
+
+    def test_create_location_token_different_for_different_locations(
+        self, auth_service: AuthService
+    ):
+        """Test that different locations get different tokens."""
+        user_id = uuid.uuid4()
+        location_id_1 = uuid.uuid4()
+        location_id_2 = uuid.uuid4()
+
+        token_1 = auth_service.create_location_token(user_id, location_id_1)
+        token_2 = auth_service.create_location_token(user_id, location_id_2)
+
+        assert token_1 != token_2
+
+    def test_create_location_token_different_for_different_users(
+        self, auth_service: AuthService
+    ):
+        """Test that different users get different tokens for the same location."""
+        user_id_1 = uuid.uuid4()
+        user_id_2 = uuid.uuid4()
+        location_id = uuid.uuid4()
+
+        token_1 = auth_service.create_location_token(user_id_1, location_id)
+        token_2 = auth_service.create_location_token(user_id_2, location_id)
+
+        assert token_1 != token_2
+
+
+class TestLocationTokenVerification:
+    """Tests for location token verification."""
+
+    def test_verify_valid_token_returns_user_id(self, auth_service: AuthService):
+        """Test that verifying a valid token returns the user ID."""
+        user_id = uuid.uuid4()
+        location_id = uuid.uuid4()
+
+        token = auth_service.create_location_token(user_id, location_id)
+        result = auth_service.verify_location_token(token, location_id)
+
+        assert result == user_id
+
+    def test_verify_token_wrong_location_returns_none(self, auth_service: AuthService):
+        """Test that verifying a token for the wrong location returns None."""
+        user_id = uuid.uuid4()
+        location_id = uuid.uuid4()
+        wrong_location_id = uuid.uuid4()
+
+        token = auth_service.create_location_token(user_id, location_id)
+        result = auth_service.verify_location_token(token, wrong_location_id)
+
+        assert result is None
+
+    def test_verify_invalid_token_returns_none(self, auth_service: AuthService):
+        """Test that verifying an invalid token returns None."""
+        location_id = uuid.uuid4()
+
+        result = auth_service.verify_location_token("invalid-token", location_id)
+
+        assert result is None
+
+    def test_verify_empty_token_returns_none(self, auth_service: AuthService):
+        """Test that verifying an empty token returns None."""
+        location_id = uuid.uuid4()
+
+        result = auth_service.verify_location_token("", location_id)
+
+        assert result is None
+
+    def test_verify_regular_access_token_returns_none(self, auth_service: AuthService):
+        """Test that a regular access token cannot be used as a location token."""
+        user_id = uuid.uuid4()
+        location_id = uuid.uuid4()
+
+        # Create a regular access token (not a location token)
+        access_token, _ = auth_service.create_access_token(user_id)
+
+        # Try to use it as a location token - should fail
+        result = auth_service.verify_location_token(access_token, location_id)
+
+        assert result is None
+
+    def test_verify_image_token_as_location_token_returns_none(
+        self, auth_service: AuthService
+    ):
+        """Test that an image token cannot be used as a location token."""
+        user_id = uuid.uuid4()
+        image_id = uuid.uuid4()
+        location_id = uuid.uuid4()
+
+        # Create an image token
+        image_token = auth_service.create_image_token(user_id, image_id)
+
+        # Try to use it as a location token - should fail
+        result = auth_service.verify_location_token(image_token, location_id)
+
+        assert result is None
+
+
+class TestLocationTokenExpiry:
+    """Tests for location token expiration."""
+
+    def test_token_expiry_constant_is_reasonable(self):
+        """Test that the token expiry is set to a reasonable value."""
+        # Token should expire within a reasonable timeframe (1-120 minutes)
+        assert 1 <= LOCATION_TOKEN_EXPIRY_MINUTES <= 120
+
+    def test_token_contains_expiry(self, auth_service: AuthService):
+        """Test that the token is created with an expiration time."""
+        from jose import jwt
+
+        user_id = uuid.uuid4()
+        location_id = uuid.uuid4()
+
+        token = auth_service.create_location_token(user_id, location_id)
+
+        # Decode without verification to check the payload
+        payload = jwt.decode(
+            token,
+            auth_service.settings.jwt_secret,
+            algorithms=[auth_service.settings.jwt_algorithm],
+        )
+
+        assert "exp" in payload
+        assert "iat" in payload
+        assert payload.get("type") == "location"
+        assert payload.get("location_id") == str(location_id)
+
+        # Verify expiry is in the future
+        exp_time = datetime.fromtimestamp(payload["exp"], tz=UTC)
+        now = datetime.now(UTC)
+        assert exp_time > now
+
+        # Verify expiry is approximately LOCATION_TOKEN_EXPIRY_MINUTES from now
+        expected_expiry = now + timedelta(minutes=LOCATION_TOKEN_EXPIRY_MINUTES)
         # Allow 5 seconds tolerance
         assert abs((exp_time - expected_expiry).total_seconds()) < 5

--- a/frontend/e2e/mocks/api-handlers.ts
+++ b/frontend/e2e/mocks/api-handlers.ts
@@ -390,8 +390,28 @@ export async function setupApiMocks(page: Page, options: MockOptions = {}) {
     });
   });
 
+  // QR code signed URL endpoint - returns a URL with a mock token
+  await page.route(
+    /\/api\/v1\/locations\/[^/]+\/qr\/signed-url/,
+    async (route) => {
+      const url = route.request().url();
+      const match = url.match(/\/locations\/([^/]+)\/qr\/signed-url/);
+      const locId = match?.[1] || "unknown";
+      const urlParams = new URL(url).searchParams;
+      const size = urlParams.get("size") || "10";
+
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          url: `http://localhost:8000/api/v1/locations/${locId}/qr?token=mock-token&size=${size}`,
+        }),
+      });
+    }
+  );
+
   // QR code endpoint - returns a small transparent PNG for testing
-  await page.route(/\/api\/v1\/locations\/[^/]+\/qr/, async (route) => {
+  await page.route(/\/api\/v1\/locations\/[^/]+\/qr(\?|$)/, async (route) => {
     // Return a 1x1 transparent PNG for testing
     const transparentPng = Buffer.from(
       "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",

--- a/frontend/src/lib/api/api-client.ts
+++ b/frontend/src/lib/api/api-client.ts
@@ -395,10 +395,10 @@ export const locationsApi = {
   getWithAncestors: (id: string) =>
     apiRequest<LocationWithAncestors>(`/api/v1/locations/${id}/with-ancestors`),
 
-  getQrCodeUrl: (id: string, size?: number) => {
-    const params = size ? `?size=${size}` : "";
-    return `${getApiBaseUrl()}/api/v1/locations/${id}/qr${params}`;
-  },
+  getQrSignedUrl: (id: string, size?: number) =>
+    apiRequest<{ url: string }>(
+      `/api/v1/locations/${id}/qr/signed-url${size ? `?size=${size}` : ""}`
+    ),
 
   getDescendants: (id: string) =>
     apiRequest<Location[]>(`/api/v1/locations/${id}/descendants`),


### PR DESCRIPTION
## Summary
- Added signed URL pattern for location QR codes (same as existing image access pattern)
- Fixed authentication issue where QR codes failed to load because browser `<img>` tags cannot send Authorization headers
- Added location token creation/verification to AuthService with 60-minute expiry

## Changes
- **Backend**: Added `GET /api/v1/locations/{id}/qr/signed-url` endpoint (authenticated) that returns a time-limited signed URL
- **Backend**: Modified `GET /api/v1/locations/{id}/qr` to accept token query parameter instead of requiring auth headers
- **Frontend**: Updated `QRCodeModal` to fetch signed URL asynchronously when modal opens or size changes
- **Tests**: Added comprehensive tests for location token creation, verification, and HTTP endpoints

## Test plan
- [x] Backend tests pass (808 tests, including 34 location router tests)
- [x] Location QR signed URL tests verify token generation and verification
- [x] Frontend lint, format, and build checks pass
- [ ] Manual testing: Open QR code modal for any location, verify image loads correctly
- [ ] Manual testing: Test download and print buttons work with signed URL

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)