### PR TITLE
fix(i18n): add missing translation keys

### DIFF
--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -5,6 +5,7 @@
     "cancel": "Abbrechen",
     "delete": "Löschen",
     "success": "Erfolg",
+    "error": "Fehler",
     "edit": "Bearbeiten",
     "create": "Erstellen",
     "update": "Aktualisieren",
@@ -433,7 +434,8 @@
     "creditTooltipPurchased": "Gekauft: {count}",
     "creditTooltipFree": "Kostenlos: {count}",
     "creditTooltipResets": "Kostenlose Credits zurückgesetzt: {date}",
-    "manageCredits": "Credits verwalten"
+    "manageCredits": "Credits verwalten",
+    "creditCost": "1 Credit"
   },
   "settings": {
     "title": "Einstellungen",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -5,6 +5,7 @@
     "cancel": "Cancel",
     "delete": "Delete",
     "success": "Success",
+    "error": "Error",
     "edit": "Edit",
     "create": "Create",
     "update": "Update",
@@ -435,7 +436,8 @@
     "creditTooltipPurchased": "Purchased: {count}",
     "creditTooltipFree": "Free: {count}",
     "creditTooltipResets": "Free credits reset: {date}",
-    "manageCredits": "Manage Credits"
+    "manageCredits": "Manage Credits",
+    "creditCost": "1 credit"
   },
   "settings": {
     "title": "Settings",

--- a/frontend/messages/es.json
+++ b/frontend/messages/es.json
@@ -5,6 +5,7 @@
     "cancel": "Cancelar",
     "delete": "Eliminar",
     "success": "Exitoso",
+    "error": "Error",
     "edit": "Editar",
     "create": "Crear",
     "update": "Actualizar",
@@ -390,7 +391,8 @@
     "creditTooltipPurchased": "Comprados: {count}",
     "creditTooltipFree": "Gratuitos: {count}",
     "creditTooltipResets": "Reinicio de créditos gratuitos: {date}",
-    "manageCredits": "Gestionar Créditos"
+    "manageCredits": "Gestionar Créditos",
+    "creditCost": "1 crédito"
   },
   "settings": {
     "title": "Configuración",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -5,6 +5,7 @@
     "cancel": "Annuler",
     "delete": "Supprimer",
     "success": "Succès",
+    "error": "Erreur",
     "edit": "Modifier",
     "create": "Créer",
     "update": "Mettre à jour",
@@ -390,7 +391,8 @@
     "creditTooltipPurchased": "Achetés : {count}",
     "creditTooltipFree": "Gratuits : {count}",
     "creditTooltipResets": "Réinitialisation des crédits gratuits : {date}",
-    "manageCredits": "Gérer les Crédits"
+    "manageCredits": "Gérer les Crédits",
+    "creditCost": "1 crédit"
   },
   "settings": {
     "title": "Paramètres",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -5,6 +5,7 @@
     "cancel": "キャンセル",
     "delete": "削除",
     "success": "成功",
+    "error": "エラー",
     "edit": "編集",
     "create": "作成",
     "update": "更新",
@@ -390,7 +391,8 @@
     "creditTooltipPurchased": "購入済み: {count}",
     "creditTooltipFree": "無料: {count}",
     "creditTooltipResets": "無料クレジットリセット: {date}",
-    "manageCredits": "クレジットを管理"
+    "manageCredits": "クレジットを管理",
+    "creditCost": "1クレジット"
   },
   "settings": {
     "title": "設定",

--- a/frontend/messages/pt-BR.json
+++ b/frontend/messages/pt-BR.json
@@ -5,6 +5,7 @@
     "cancel": "Cancelar",
     "delete": "Excluir",
     "success": "Sucesso",
+    "error": "Erro",
     "edit": "Editar",
     "create": "Criar",
     "update": "Atualizar",
@@ -390,7 +391,8 @@
     "creditTooltipPurchased": "Comprados: {count}",
     "creditTooltipFree": "Gratuitos: {count}",
     "creditTooltipResets": "Renovação dos créditos gratuitos: {date}",
-    "manageCredits": "Gerenciar Créditos"
+    "manageCredits": "Gerenciar Créditos",
+    "creditCost": "1 crédito"
   },
   "settings": {
     "title": "Configurações",


### PR DESCRIPTION
## Summary
- Add `common.error` translation key used by `tCommon("error")` for toast error titles
- Add `billing.creditCost` translation key used for credit cost display on the new item page

## Files affected
- `components/items/image-gallery.tsx` - uses `tCommon("error")`
- `components/locations/location-photo.tsx` - uses `tCommon("error")`
- `app/(dashboard)/items/batch-upload/page.tsx` - uses `tCommon("error")`
- `app/(dashboard)/settings/collaboration/page.tsx` - uses `tCommon("error")`
- `app/(dashboard)/items/new/page.tsx` - uses `t("billing.creditCost")`

## Test plan
- [ ] Verify error toasts display correctly (trigger an error in image upload/removal)
- [ ] Verify credit cost displays correctly on new item page when suggesting locations
- [ ] Check non-English locales display translated strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)