### PR TITLE
feat(security): add ALLOWED_NETWORKS setting to allowlist IP ranges

### DIFF
--- a/backend/src/config.py
+++ b/backend/src/config.py
@@ -76,7 +76,13 @@ class Settings(BaseSettings):
     redis_url: str | None = None  # e.g., "redis://localhost:6379"
 
     # SSRF allowlist - comma-separated CIDR ranges to exempt from blocked networks
-    # e.g., "10.0.1.0/24,192.168.50.0/24" to allow internal services
+    # WARNING: This bypasses SSRF protection. Only use for trusted internal services.
+    # Networks must use proper CIDR notation (e.g., 10.0.1.0/24, not 10.0.1.5/24).
+    # Examples:
+    #   Single subnet: "10.0.1.0/24"
+    #   Multiple subnets: "10.0.1.0/24,192.168.50.0/24"
+    #   Single IP: "10.0.0.5/32"
+    # SECURITY: Ensure this is properly restricted in production environments.
     allowed_networks: str = ""
 
     def _is_production_environment(self) -> bool:


### PR DESCRIPTION
## Summary
- Add `ALLOWED_NETWORKS` environment variable to exempt specific IP ranges from SSRF protection
- Enables calls to internal network services while maintaining security for other private ranges
- Uses comma-separated CIDR notation (e.g., `10.0.1.0/24,192.168.50.0/24`)

## Usage
```env
# Allow a specific subnet
ALLOWED_NETWORKS=10.0.1.0/24

# Allow multiple subnets
ALLOWED_NETWORKS=10.0.1.0/24,192.168.50.0/24

# Allow a single IP
ALLOWED_NETWORKS=10.0.0.5/32
```

## Test plan
- [x] Unit tests for `is_ip_allowed()` function
- [x] Tests for allowlist bypassing blocked networks
- [x] Tests for IPs outside allowlist still being blocked
- [x] Tests for invalid network entries being ignored
- [x] Tests for webhook URL validation with allowed IPs

🤖 Generated with [Claude Code](https://claude.com/claude-code)