### PR TITLE
fix(declutter): add feedback when no items eligible for declutter

### DIFF
--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -495,6 +495,8 @@
     "credits": "Credits",
     "generateComplete": "Analyse abgeschlossen",
     "generateCompleteDescription": "{count} Artikel zur Überprüfung gefunden, {credits} Credits verwendet",
+    "noItemsToSuggest": "Keine Artikel zum Ausmisten",
+    "noItemsToSuggestDescription": "Gute Neuigkeiten! Basierend auf Ihren Profileinstellungen müssen derzeit keine Ihrer Artikel ausgemistet werden.",
     "generateError": "Vorschläge konnten nicht generiert werden. Bitte versuchen Sie es erneut.",
     "updateError": "Empfehlung konnte nicht aktualisiert werden",
     "resultsTitle": "Vorschläge",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -495,6 +495,8 @@
     "credits": "credits",
     "generateComplete": "Analysis Complete",
     "generateCompleteDescription": "Found {count} items to review, used {credits} credits",
+    "noItemsToSuggest": "No Items to Declutter",
+    "noItemsToSuggestDescription": "Great news! Based on your profile settings, none of your items need decluttering right now.",
     "generateError": "Failed to generate suggestions. Please try again.",
     "updateError": "Failed to update recommendation",
     "resultsTitle": "Suggestions",

--- a/frontend/messages/es.json
+++ b/frontend/messages/es.json
@@ -451,6 +451,8 @@
     "credits": "créditos",
     "generateComplete": "Análisis Completado",
     "generateCompleteDescription": "Se encontraron {count} artículos para revisar, se usaron {credits} créditos",
+    "noItemsToSuggest": "Sin Artículos para Ordenar",
+    "noItemsToSuggestDescription": "¡Buenas noticias! Según la configuración de tu perfil, ninguno de tus artículos necesita ser ordenado en este momento.",
     "generateError": "Error al generar sugerencias. Por favor, inténtalo de nuevo.",
     "updateError": "Error al actualizar la recomendación",
     "resultsTitle": "Sugerencias",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -451,6 +451,8 @@
     "credits": "crédits",
     "generateComplete": "Analyse Terminée",
     "generateCompleteDescription": "{count} articles trouvés à examiner, {credits} crédits utilisés",
+    "noItemsToSuggest": "Aucun Article à Désencombrer",
+    "noItemsToSuggestDescription": "Bonne nouvelle ! Selon les paramètres de votre profil, aucun de vos articles n'a besoin d'être désencombré pour le moment.",
     "generateError": "Échec de la génération des suggestions. Veuillez réessayer.",
     "updateError": "Échec de la mise à jour de la recommandation",
     "resultsTitle": "Suggestions",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -451,6 +451,8 @@
     "credits": "クレジット",
     "generateComplete": "分析完了",
     "generateCompleteDescription": "レビューする{count}件のアイテムが見つかり、{credits}クレジットを使用しました",
+    "noItemsToSuggest": "整理するアイテムはありません",
+    "noItemsToSuggestDescription": "良いニュースです！プロフィール設定に基づくと、現在整理が必要なアイテムはありません。",
     "generateError": "提案の生成に失敗しました。もう一度お試しください。",
     "updateError": "推奨の更新に失敗しました",
     "resultsTitle": "提案",

--- a/frontend/messages/pt-BR.json
+++ b/frontend/messages/pt-BR.json
@@ -451,6 +451,8 @@
     "credits": "créditos",
     "generateComplete": "Análise Concluída",
     "generateCompleteDescription": "Encontrados {count} itens para revisar, usados {credits} créditos",
+    "noItemsToSuggest": "Nenhum Item para Organizar",
+    "noItemsToSuggestDescription": "Ótimas notícias! Com base nas configurações do seu perfil, nenhum dos seus itens precisa ser organizado no momento.",
     "generateError": "Falha ao gerar sugestões. Por favor, tente novamente.",
     "updateError": "Falha ao atualizar recomendação",
     "resultsTitle": "Sugestões",

--- a/frontend/src/app/(dashboard)/declutter-suggestions/page.tsx
+++ b/frontend/src/app/(dashboard)/declutter-suggestions/page.tsx
@@ -130,13 +130,20 @@ export default function DeclutterSuggestionsPage() {
       await refreshCredits();
       await loadCostInfo(itemsToAnalyze);
 
-      toast({
-        title: t("generateComplete"),
-        description: t("generateCompleteDescription", {
-          count: response.total_generated,
-          credits: response.credits_used,
-        }),
-      });
+      if (response.total_generated === 0) {
+        toast({
+          title: t("noItemsToSuggest"),
+          description: t("noItemsToSuggestDescription"),
+        });
+      } else {
+        toast({
+          title: t("generateComplete"),
+          description: t("generateCompleteDescription", {
+            count: response.total_generated,
+            credits: response.credits_used,
+          }),
+        });
+      }
     } catch (error: unknown) {
       const apiError = error as { status?: number };
       if (apiError.status === 402) {


### PR DESCRIPTION
## Summary
- Added specific toast notification when declutter analysis returns 0 items to suggest
- Shows "No Items to Declutter" with an encouraging message instead of "Found 0 items to review"
- Added translations for the new messages in all 6 supported languages (en, de, es, fr, ja, pt-BR)

## Test plan
- [ ] Navigate to Declutter Suggestions page
- [ ] Configure a system profile if not already done
- [ ] Run "Generate Suggestions" on an inventory that has no items eligible for decluttering
- [ ] Verify a toast appears with "No Items to Declutter" title and positive feedback message
- [ ] Test that normal behavior (items found) still shows the original success message

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)