### PR TITLE
feat(items): add batch upload button to items page

### DIFF
--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -195,7 +195,8 @@
     "createCategoryHierarchy": "Kategorie-Hierarchie erstellen?",
     "categoryCreationDescription": "Dies erstellt die folgenden Kategorien:",
     "underParent": "unter {parent}",
-    "existingCategoriesReused": "Vorhandene Kategorien mit übereinstimmenden Namen werden wiederverwendet."
+    "existingCategoriesReused": "Vorhandene Kategorien mit übereinstimmenden Namen werden wiederverwendet.",
+    "batchUpload": "Stapel-Upload"
   },
   "categories": {
     "title": "Kategorien",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -195,7 +195,8 @@
     "createCategoryHierarchy": "Create Category Hierarchy?",
     "categoryCreationDescription": "This will create the following categories:",
     "underParent": "under {parent}",
-    "existingCategoriesReused": "Existing categories with matching names will be reused."
+    "existingCategoriesReused": "Existing categories with matching names will be reused.",
+    "batchUpload": "Batch Upload"
   },
   "categories": {
     "title": "Categories",

--- a/frontend/messages/es.json
+++ b/frontend/messages/es.json
@@ -162,7 +162,8 @@
     "clearLocation": "Quitar ubicación",
     "applyChanges": "Aplicar Cambios",
     "batchUpdateSuccess": "Se actualizaron {count} artículos exitosamente",
-    "selectItems": "Selecciona artículos para actualizar en lote"
+    "selectItems": "Selecciona artículos para actualizar en lote",
+    "batchUpload": "Subida en Lote"
   },
   "categories": {
     "title": "Categorías",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -162,7 +162,8 @@
     "clearLocation": "Effacer l'emplacement",
     "applyChanges": "Appliquer les Modifications",
     "batchUpdateSuccess": "{count} articles mis à jour avec succès",
-    "selectItems": "Sélectionnez des articles pour la mise à jour groupée"
+    "selectItems": "Sélectionnez des articles pour la mise à jour groupée",
+    "batchUpload": "Téléversement Groupé"
   },
   "categories": {
     "title": "Catégories",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -162,7 +162,8 @@
     "clearLocation": "ロケーションをクリア",
     "applyChanges": "変更を適用",
     "batchUpdateSuccess": "{count}件のアイテムが正常に更新されました",
-    "selectItems": "一括更新するアイテムを選択してください"
+    "selectItems": "一括更新するアイテムを選択してください",
+    "batchUpload": "一括アップロード"
   },
   "categories": {
     "title": "カテゴリー",

--- a/frontend/messages/pt-BR.json
+++ b/frontend/messages/pt-BR.json
@@ -162,7 +162,8 @@
     "clearLocation": "Limpar local",
     "applyChanges": "Aplicar Alterações",
     "batchUpdateSuccess": "{count} itens atualizados com sucesso",
-    "selectItems": "Selecione itens para atualização em lote"
+    "selectItems": "Selecione itens para atualização em lote",
+    "batchUpload": "Upload em Lote"
   },
   "categories": {
     "title": "Categorias",

--- a/frontend/src/app/(dashboard)/items/page.tsx
+++ b/frontend/src/app/(dashboard)/items/page.tsx
@@ -21,6 +21,7 @@ import {
   Square,
   FolderX,
   MapPinOff,
+  Upload,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { InlineFacetedFilter } from "@/components/items/faceted-filter";
@@ -351,6 +352,15 @@ export default function ItemsPage() {
                 <Square className="h-4 w-4" />
                 {t("selectItems")}
               </Button>
+              <Link
+                href="/items/batch-upload"
+                data-testid="batch-upload-button"
+              >
+                <Button variant="outline" className="w-full gap-2 sm:w-auto">
+                  <Upload className="h-4 w-4" />
+                  {t("batchUpload")}
+                </Button>
+              </Link>
               <Link href="/items/new" data-testid="add-item-button">
                 <Button className="w-full sm:w-auto">
                   <Plus className="mr-2 h-4 w-4" />


### PR DESCRIPTION
## Summary
- Add a "Batch Upload" button to the items page header that links to the existing `/items/batch-upload` page
- Makes it easier to discover and access the bulk item creation feature
- Includes translations for all 6 locales (en, de, es, fr, ja, pt-BR)

## Test plan
- [ ] Navigate to the Items page
- [ ] Verify the "Batch Upload" button appears between "Select items" and "Add Item" buttons
- [ ] Click the button and verify it navigates to `/items/batch-upload`
- [ ] Test in different languages to verify translations work

🤖 Generated with [Claude Code](https://claude.com/claude-code)