### PR TITLE
feat(health): enhance health check for Kubernetes probes

### DIFF
--- a/backend/src/database.py
+++ b/backend/src/database.py
@@ -95,3 +95,20 @@ async def get_session() -> AsyncGenerator[AsyncSession, None]:
 
 # Type alias for dependency injection
 AsyncSessionDep = Annotated[AsyncSession, Depends(get_session)]
+
+
+async def check_db_connectivity() -> bool:
+    """
+    Check database connectivity by executing a simple query.
+
+    Returns True if the database is reachable, False otherwise.
+    """
+    if _session_factory is None:
+        return False
+
+    try:
+        async with _session_factory() as session:
+            await session.execute(text("SELECT 1"))
+            return True
+    except Exception:
+        return False

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,5 +1,19 @@
-def test_health_check(client):
-    """Test health check endpoint returns healthy status with database connection."""
-    response = client.get("/health")
-    assert response.status_code == 200
-    assert response.json() == {"status": "healthy", "database": "connected"}
+from unittest.mock import AsyncMock, patch
+
+
+def test_health_check_healthy(client):
+    """Test health check returns healthy status when database is connected."""
+    with patch("src.main.check_db_connectivity", new_callable=AsyncMock) as mock_check:
+        mock_check.return_value = True
+        response = client.get("/health")
+        assert response.status_code == 200
+        assert response.json() == {"status": "healthy", "database": "connected"}
+
+
+def test_health_check_unhealthy(client):
+    """Test health check returns unhealthy status when database is unavailable."""
+    with patch("src.main.check_db_connectivity", new_callable=AsyncMock) as mock_check:
+        mock_check.return_value = False
+        response = client.get("/health")
+        assert response.status_code == 503
+        assert response.json() == {"status": "unhealthy", "database": "disconnected"}


### PR DESCRIPTION
## Summary
- Enhanced `/health` endpoint to check database connectivity
- Returns HTTP 200 with `{"status": "healthy", "database": "connected"}` when healthy
- Returns HTTP 503 with `{"status": "unhealthy", "database": "disconnected"}` when database unavailable

## Test plan
- [x] Existing health check test updated and passing
- [ ] Verify endpoint returns 200 when database is available
- [ ] Verify endpoint returns 503 when database is unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)