### PR TITLE
fix(feedback): preserve existing status when null is passed to admin update

### DIFF
--- a/backend/src/feedback/repository.py
+++ b/backend/src/feedback/repository.py
@@ -106,7 +106,7 @@ class FeedbackRepository:
 
     async def update(self, feedback: Feedback, data: FeedbackAdminUpdate) -> Feedback:
         """Update feedback (admin only)."""
-        update_data = data.model_dump(exclude_unset=True)
+        update_data = data.model_dump(exclude_unset=True, exclude_none=True)
         for field, value in update_data.items():
             setattr(feedback, field, value)
         await self.session.commit()


### PR DESCRIPTION
## Summary
- Fixed bug where passing `{"status": null}` to `PUT /api/v1/feedback/admin/{id}` would set status to null instead of preserving the existing value
- Added `exclude_none=True` to `model_dump()` in feedback repository update method
- Added comprehensive tests for null status handling

## Changes
- `backend/src/feedback/repository.py`: Added `exclude_none=True` to exclude explicitly null values from updates
- `backend/tests/feedback/test_feedback_router.py`: Added tests for null status preservation

## Test plan
- [x] All feedback tests pass (23/23)
- [x] New test `test_update_feedback_with_null_status_preserves_existing` verifies null status preservation
- [x] New test `test_update_feedback_with_only_admin_notes` verifies omitted status is preserved
- [x] Code passes ruff linting and formatting checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)