### PR TITLE
fix(ai): improve link visibility in AI assistant chat

### DIFF
--- a/frontend/src/app/(dashboard)/ai-assistant/page.tsx
+++ b/frontend/src/app/(dashboard)/ai-assistant/page.tsx
@@ -56,7 +56,10 @@ const MarkdownLink = ({
     }
 
     return (
-      <Link href={href} className="text-primary font-medium hover:underline">
+      <Link
+        href={href}
+        className="font-medium text-blue-600 underline decoration-blue-600/50 hover:decoration-blue-600 dark:text-blue-400 dark:decoration-blue-400/50 dark:hover:decoration-blue-400"
+      >
         {children}
       </Link>
     );
@@ -67,7 +70,7 @@ const MarkdownLink = ({
       href={href}
       target="_blank"
       rel="noopener noreferrer"
-      className="text-primary hover:underline"
+      className="text-blue-600 underline decoration-blue-600/50 hover:decoration-blue-600 dark:text-blue-400 dark:decoration-blue-400/50 dark:hover:decoration-blue-400"
     >
       {children}
     </a>


### PR DESCRIPTION
## Summary
- Style item/category/location links in AI assistant chat with distinct blue color (`text-blue-600` / `text-blue-400` for dark mode)
- Add subtle underline with hover effect for better link affordance
- Previously links used `text-primary` which blends with text in dark mode making them hard to identify as clickable

## Test plan
- [ ] Open AI assistant chat
- [ ] Send a message that prompts the AI to link to an item (e.g., "what items do I have?")
- [ ] Verify links are clearly blue and underlined in both light and dark mode
- [ ] Verify hover state makes underline more prominent

🤖 Generated with [Claude Code](https://claude.com/claude-code)