### PR TITLE
fix(i18n): add missing inventory.viewer and inventory.editor translations

### DIFF
--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -1230,7 +1230,9 @@
     "myInventory": "Mein Inventar",
     "sharedInventory": "Geteiltes Inventar",
     "sharedWithMe": "Mit mir geteilt",
-    "viewingInventoryOf": "Anzeige von {name}s Inventar"
+    "viewingInventoryOf": "Anzeige von {name}s Inventar",
+    "viewer": "Betrachter",
+    "editor": "Bearbeiter"
   },
   "landing": {
     "nav": {

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1232,7 +1232,9 @@
     "myInventory": "My Inventory",
     "sharedInventory": "Shared Inventory",
     "sharedWithMe": "Shared with me",
-    "viewingInventoryOf": "Viewing {name}'s inventory"
+    "viewingInventoryOf": "Viewing {name}'s inventory",
+    "viewer": "Viewer",
+    "editor": "Editor"
   },
   "landing": {
     "nav": {

--- a/frontend/messages/es.json
+++ b/frontend/messages/es.json
@@ -1231,7 +1231,9 @@
     "myInventory": "Mi Inventario",
     "sharedInventory": "Inventario Compartido",
     "sharedWithMe": "Compartido conmigo",
-    "viewingInventoryOf": "Viendo el inventario de {name}"
+    "viewingInventoryOf": "Viendo el inventario de {name}",
+    "viewer": "Visualizador",
+    "editor": "Editor"
   },
   "landing": {
     "nav": {

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -1231,7 +1231,9 @@
     "myInventory": "Mon Inventaire",
     "sharedInventory": "Inventaire Partagé",
     "sharedWithMe": "Partagé avec moi",
-    "viewingInventoryOf": "Consultation de l'inventaire de {name}"
+    "viewingInventoryOf": "Consultation de l'inventaire de {name}",
+    "viewer": "Lecteur",
+    "editor": "Éditeur"
   },
   "landing": {
     "nav": {

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -1235,7 +1235,9 @@
     "myInventory": "マイ在庫",
     "sharedInventory": "共有在庫",
     "sharedWithMe": "共有された在庫",
-    "viewingInventoryOf": "{name}の在庫を表示中"
+    "viewingInventoryOf": "{name}の在庫を表示中",
+    "viewer": "閲覧者",
+    "editor": "編集者"
   },
   "landing": {
     "nav": {

--- a/frontend/messages/pt-BR.json
+++ b/frontend/messages/pt-BR.json
@@ -1235,7 +1235,9 @@
     "myInventory": "Meu Inventário",
     "sharedInventory": "Inventário Compartilhado",
     "sharedWithMe": "Compartilhado comigo",
-    "viewingInventoryOf": "Visualizando o inventário de {name}"
+    "viewingInventoryOf": "Visualizando o inventário de {name}",
+    "viewer": "Visualizador",
+    "editor": "Editor"
   },
   "landing": {
     "nav": {

--- a/frontend/src/app/(dashboard)/items/new/page.tsx
+++ b/frontend/src/app/(dashboard)/items/new/page.tsx
@@ -770,7 +770,7 @@ export default function NewItemPage() {
           <div className="grid gap-4 sm:grid-cols-4">
             <div>
               <label className="mb-2 block text-sm font-medium">
-                {tItems("quantity")}
+                {tCommon("quantity")}
               </label>
               <input
                 type="number"


### PR DESCRIPTION
## Summary
- Added missing `inventory.viewer` and `inventory.editor` translation keys to all 6 locale files
- Fixes console errors in sidebar and header components when displaying user roles for shared inventories

## Test plan
- [ ] Start dev server and verify no `MISSING_MESSAGE` errors in console
- [ ] View a shared inventory to confirm Viewer/Editor badges display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)